### PR TITLE
INFRA-7027: Allow ip_reverse module to run on vrack IP blocks

### DIFF
--- a/plugins/modules/ip_reverse.py
+++ b/plugins/modules/ip_reverse.py
@@ -23,6 +23,10 @@ options:
     reverse:
         required: true
         description: The reverse to assign
+    ip_block:
+        required: false
+        description: The ipBlock (only for vrack IPs)
+        default: None
 
 '''
 
@@ -36,6 +40,7 @@ delegate_to: localhost
 RETURN = ''' # '''
 
 from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+import urllib.parse
 
 try:
     from ovh.exceptions import APIError, ResourceNotFoundError
@@ -48,7 +53,8 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         ip=dict(required=True),
-        reverse=dict(required=True)
+        reverse=dict(required=True),
+        ip_block=dict(required=False, default=None)
     ))
 
     module = AnsibleModule(
@@ -59,13 +65,21 @@ def run_module():
 
     ip = module.params['ip']
     reverse = module.params['reverse']
+    ip_block = module.params['ip_block']
+
+    # ip_block is only needed for vrack IPs. Default it to "ip" when not used
+    if ip_block is None:
+        ip_block = ip
+    else:
+        # url encode the ip mask (/26 -> %2F)
+        ip_block = urllib.parse.quote(ip_block, safe='')
 
     if module.check_mode:
         module.exit_json(msg="Reverse {} to {} succesfully set ! - (dry run mode)".format(ip, reverse), changed=True)
 
     result = {}
     try:
-        result = client.get('/ip/%s/reverse/%s' % (ip, ip))
+        result = client.get('/ip/%s/reverse/%s' % (ip_block, ip))
     except ResourceNotFoundError:
         result['reverse'] = ''
 
@@ -74,7 +88,7 @@ def run_module():
 
     try:
         client.post(
-            '/ip/%s/reverse' % ip,
+            '/ip/%s/reverse' % ip_block,
             ipReverse=ip,
             reverse=reverse
         )


### PR DESCRIPTION
- Reverse API call needs 2 parameters: ipblock and ip.
- On dedicated
instances or cloud instances, both are equal.
- But on vrack ranges, you need to set the "ipBlock" of the IP you want
to add the reverse to.
- This fixes
https://github.com/synthesio/infra-ovh-ansible-module/issues/13