### PR TITLE
Add volumeName value to partitionScheme partition

### DIFF
--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -190,6 +190,8 @@ def run_module():
     partition = {}
     for k in conf['partition']:
         partition = ast.literal_eval(k)
+        if 'volumeName' not in partition.keys():
+            partition['volumeName'] = ""
         try:
             if 'raid' in partition.keys():
                 client.post(
@@ -200,7 +202,9 @@ def run_module():
                     raid=partition['raid'],
                     size=partition['size'],
                     step=partition['step'],
-                    type=partition['type'])
+                    type=partition['type'],
+                    volumeName=partition['volumeName'],
+                    )
             else:
                 client.post(
                     '/me/installationTemplate/%s/partitionScheme/%s/partition' % (
@@ -209,7 +213,9 @@ def run_module():
                     mountpoint=partition['mountpoint'],
                     size=partition['size'],
                     step=partition['step'],
-                    type=partition['type'])
+                    type=partition['type'],
+                    volumeName=partition['volumeName'],
+                    )
         except APIError as api_error:
             module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
     try:


### PR DESCRIPTION
Hi,
when pushing a software raid template to OVH API, lv type partitions are not pushed correctly. For instance with the following template:

```
templateName: 'proxmoxraid0'
baseTemplateName: 'proxmox6_64'
distribution: 'proxmox6'
customHostname: 'proxmox1.templateraid0'
sshKeyName: 'redacted'
useDistributionKernel: false
defaultLanguage: 'fr'
partitionScheme: 'custom'
partitionSchemePriority: 1
isSoftwareRaid: true
isHardwareRaid: false
lvmReady: true
partition:
  - "{'filesystem':'ext4','mountpoint':'/','raid':'0','size':'25000','step':'1','type':'primary'}"
  - "{'filesystem':'swap','mountpoint':'swap','raid':'0','size':'4096','step':'2','type':'primary'}"
  - "{'filesystem':'ext4','mountpoint':'/var/lib/vz','raid':'0','size':'0','step':'3','type':'lv','volumeName':'data'}"
postInstallationScriptLink: ''
postInstallationScriptReturn: ''
```

The following error is returned:
```
"Failed to call OVH API: 1 Error(s) founds : Bad LVM volume name:    \nOVH-Query-ID: _redacted_"
```

The optional parameter volumeName isn't pushed in the current version of the module, so I added it. It works now with every type of partition. For partitions not requiring a volumeName, there is no side effect when pushing the parameter as an empty string.