### PR TITLE
Improve install pci, search image in snapshot + check if instance is …

### DIFF
--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -84,7 +84,7 @@ def run_module():
             try:
                 client.delete('/me/installationTemplate/%s' % src_template)
 
-                module.exit_json(msg="Template {} succesfully deleted".format(src_template, changed=True))
+                module.exit_json(msg="Template {} succesfully deleted".format(src_template), changed=True)
             except APIError as api_error:
                 module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
         else:
@@ -153,28 +153,28 @@ def run_module():
         # All the disks in this controller are taken to form one raid
         # In the future, some of our servers could have more than one controller
         # so we will have to adapt this code
-        
+
         diskarray = result['controllers'][0]['disks'][0]['names']
         disks = []
 
         if conf['raidMode'] == 'raid1':
             # In raid1, we take the first two disks in the disk array
-            disks = [ diskarray[0],diskarray[1] ]
+            disks = [diskarray[0], diskarray[1]]
 
-        elif conf['raidMode'] == 'raid10' or conf['raidMode'] == 'raid60' :
+        elif conf['raidMode'] == 'raid10' or conf['raidMode'] == 'raid60':
             # In raid10 or raid60, we configure two disk groups
-            groups = [[],[]]
-            for i in range ( len(diskarray) ):
-                if i <  (len(diskarray) // 2):
+            groups = [[], []]
+            for i in range(len(diskarray)):
+                if i < (len(diskarray) // 2):
                     groups[0].append(diskarray[i])
                 else:
                     groups[1].append(diskarray[i])
             sep = ','
-            disks = [ '[' + (sep.join(groups[0])) + ']' , '[' + (sep.join(groups[1])) + ']' ]
+            disks = ['[' + (sep.join(groups[0])) + ']', '[' + (sep.join(groups[1])) + ']']
 
         else:
             # Fallback condition: pass every disk in the array (will be applied for raid0)
-           disks = diskarray
+            disks = diskarray
 
         try:
             result = client.post(
@@ -203,8 +203,7 @@ def run_module():
                     size=partition['size'],
                     step=partition['step'],
                     type=partition['type'],
-                    volumeName=partition['volumeName'],
-                    )
+                    volumeName=partition['volumeName'])
             else:
                 client.post(
                     '/me/installationTemplate/%s/partitionScheme/%s/partition' % (
@@ -214,8 +213,7 @@ def run_module():
                     size=partition['size'],
                     step=partition['step'],
                     type=partition['type'],
-                    volumeName=partition['volumeName'],
-                    )
+                    volumeName=partition['volumeName'])
         except APIError as api_error:
             module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
     try:

--- a/plugins/modules/public_cloud_imageid_info.py
+++ b/plugins/modules/public_cloud_imageid_info.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: public_cloud_imageid_info
-short_description: Get flavor id based on commercial name
+short_description: Get image id based on human name in ovh repository or in own snapshot repository
 description:
     - Get imageid based on commercial name (t1-45, b2-7 etc)
     - The imageid change between region
@@ -70,19 +70,29 @@ def run_module():
     name = module.params['name']
     region = module.params['region']
 
+    # Get images list
     try:
-        result = client.get('/cloud/project/%s/image' % (service_name),
+        result_image = client.get('/cloud/project/%s/image' % (service_name),
                             region=region
                             )
-        for i in result:
-            if i['name'] == name:
-                image_id = i['id']
-                module.exit_json(changed=False, id=image_id)
-
-        module.fail_json(msg="Image {} not found in {}".format(name, region), changed=False)
-
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+    # Get snapshot list
+    try:
+        result_snapshot = client.get('/cloud/project/%s/snapshot' % (service_name),
+                            region=region
+                            )
+    except APIError as api_error:
+        module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+    # search in both list
+    for i in (result_image + result_snapshot):
+        if i['name'] == name:
+            image_id = i['id']
+            module.exit_json(changed=False, id=image_id)
+
+    module.fail_json(msg="Image {} not found in {}".format(name, region), changed=False)
 
 
 def main():

--- a/plugins/modules/public_cloud_imageid_info.py
+++ b/plugins/modules/public_cloud_imageid_info.py
@@ -73,16 +73,14 @@ def run_module():
     # Get images list
     try:
         result_image = client.get('/cloud/project/%s/image' % (service_name),
-                            region=region
-                            )
+                                  region=region)
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
     # Get snapshot list
     try:
         result_snapshot = client.get('/cloud/project/%s/snapshot' % (service_name),
-                            region=region
-                            )
+                                     region=region)
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 

--- a/plugins/modules/public_cloud_instance.py
+++ b/plugins/modules/public_cloud_instance.py
@@ -115,11 +115,9 @@ def run_module():
     monthly_billing = module.params['monthly_billing']
     force_reinstall = module.params['force_reinstall']
 
-
     try:
         instances_list = client.get('/cloud/project/%s/instance' % (service_name),
-                            region=region
-                            )
+                                    region=region)
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
@@ -127,20 +125,21 @@ def run_module():
 
         if i['name'] == name:
             instance_id = i['id']
-            instance_details = client.get('/cloud/project/%s/instance/%s' % (service_name,instance_id ))
+            instance_details = client.get('/cloud/project/%s/instance/%s' % (service_name, instance_id))
 
             if force_reinstall:
                 try:
                     reinstall_result = client.post(
-                                        '/cloud/project/%s/instance/%s/reinstall' % (service_name,instance_id),
-                                         imageId=image_id
-                                         )
+                        '/cloud/project/%s/instance/%s/reinstall' % (service_name, instance_id),
+                        imageId=image_id)
                     module.exit_json(changed=True, **reinstall_result)
 
                 except APIError as api_error:
                     module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
-            module.exit_json(changed=False, msg="Instance {} [{}] in region {} is already installed".format(name, instance_id, region), **instance_details)
+            module.exit_json(changed=False,
+                             msg="Instance {} [{}] in region {} is already installed".format(name, instance_id, region),
+                             **instance_details)
 
     try:
         result = client.post('/cloud/project/%s/instance' % service_name,

--- a/plugins/modules/public_cloud_instance.py
+++ b/plugins/modules/public_cloud_instance.py
@@ -140,7 +140,7 @@ def run_module():
                 except APIError as api_error:
                     module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
-            module.exit_json(changed=False,**instance_details)
+            module.exit_json(changed=False, msg="Instance {} [{}] in region {} is already installed".format(name, instance_id, region), **instance_details)
 
     try:
         result = client.post('/cloud/project/%s/instance' % service_name,


### PR DESCRIPTION
Hi again ;)

I add some improvement into public cloud installation.
Now we can install an instance based on snapshot ( for example if you import your qcow2 image in ovh openstack )
Check before create instance if an instance with the same name and in same datacenter, is already created, and if this instance exist, skip the command of install, except if we want force a new installation.
