### PR TITLE
domain plugin: Adds support for DKIM and SPF records

### DIFF
--- a/plugins/modules/domain.py
+++ b/plugins/modules/domain.py
@@ -28,7 +28,7 @@ options:
         description: The domain to modify
     record_type:
         required: false
-        description: The DNS record type (A, CNAME, TXT, AAAA, NS, SRV, MX)
+        description: The DNS record type (A, CNAME, TXT, AAAA, NS, SRV, MX, , DKIM, SPF)
     state:
         required: false
         description: The state
@@ -61,7 +61,7 @@ def run_module():
         value=dict(required=True),
         name=dict(required=True),
         domain=dict(required=True),
-        record_type=dict(choices=['A', 'CNAME', 'TXT', 'AAAA', 'NS', 'SRV', 'MX'], default='A'),
+        record_type=dict(choices=['A', 'CNAME', 'TXT', 'AAAA', 'NS', 'SRV', 'MX', 'DKIM', 'SPF'], default='A'),
         state=dict(choices=['present', 'absent'], default='present')
     ))
 


### PR DESCRIPTION
This PR only adds DKIM and SPF record types to be able to manage such records using domain plugin