### PR TITLE
Allow to specify the number of disks in the raid software

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ A few examples:
     sleep: "10"
 ```
 
+### Install a new dedicated server with only 2 disks
+
+```yaml
+- Install new dedicated server
+  synthesio.ovh.dedicated_server_install:
+    service_name: "ns12345.ip-1-2-3.eu"
+    hostname: "server01.example.net"
+    template: "debian10_64"
+    soft_raid_devices: "2"
+
+```
+
 ### Install a public cloud instance
 
 ```yaml

--- a/plugins/modules/dedicated_server_install.py
+++ b/plugins/modules/dedicated_server_install.py
@@ -25,7 +25,7 @@ options:
     template:
         required: true
         description: template to use to spawn the server
-    sshKeyName:
+    ssh_key_name:
         required: false
         description: sshkey to deploy
     soft_raid_devices:
@@ -60,7 +60,7 @@ def run_module():
         service_name=dict(required=True),
         hostname=dict(required=True),
         template=dict(required=True),
-        sshKeyName=dict(required=False, default=None),
+        ssh_key_name=dict(required=False, default=None),
         soft_raid_devices=dict(required=False, default=None)
     ))
 
@@ -73,7 +73,7 @@ def run_module():
     service_name = module.params['service_name']
     hostname = module.params['hostname']
     template = module.params['template']
-    sshKeyName = module.params['sshKeyName']
+    ssh_key_name = module.params['ssh_key_name']
     soft_raid_devices = module.params['soft_raid_devices']
 
     if module.check_mode:
@@ -92,7 +92,7 @@ def run_module():
     details = {"details":
                {"language": "en",
                 "customHostname": hostname,
-                "sshKeyName": sshKeyName,
+                "sshKeyName": ssh_key_name,
                 "softRaidDevices": soft_raid_devices}
                }
 

--- a/plugins/modules/dedicated_server_install.py
+++ b/plugins/modules/dedicated_server_install.py
@@ -28,6 +28,9 @@ options:
     sshKeyName:
         required: false
         description: sshkey to deploy
+    soft_raid_devices:
+        required: false
+        description: number of devices in the raid software
 
 '''
 
@@ -36,6 +39,7 @@ synthesio.ovh.dedicated_server_install:
     service_name: "ns12345.ip-1-2-3.eu"
     hostname: "server01.example.net"
     template: "debian10_64"
+    soft_raid_devices: "2"
 delegate_to: localhost
 '''
 
@@ -56,7 +60,8 @@ def run_module():
         service_name=dict(required=True),
         hostname=dict(required=True),
         template=dict(required=True),
-        sshKeyName=dict(required=False, default=None)
+        sshKeyName=dict(required=False, default=None),
+        soft_raid_devices=dict(required=False, default=None)
     ))
 
     module = AnsibleModule(
@@ -69,6 +74,7 @@ def run_module():
     hostname = module.params['hostname']
     template = module.params['template']
     sshKeyName = module.params['sshKeyName']
+    soft_raid_devices = module.params['soft_raid_devices']
 
     if module.check_mode:
         module.exit_json(msg="Installation in progress on {} as {} with template {} - (dry run mode)".format(service_name, hostname, template),
@@ -86,7 +92,8 @@ def run_module():
     details = {"details":
                {"language": "en",
                 "customHostname": hostname,
-                "sshKeyName": sshKeyName}
+                "sshKeyName": sshKeyName,
+                "softRaidDevices": soft_raid_devices}
                }
 
     try:


### PR DESCRIPTION
  Add the `softRaidDevices` parameter to the call to install a dedicated server using only a provided amount of disks.  
  Change camelcase for sshKeyName on ansible side.