### PR TITLE
INFRA-7398: Add workaround for new servers with more than 1 interface on the same link

### DIFF
--- a/plugins/modules/dedicated_server_networkinterfacecontroller.py
+++ b/plugins/modules/dedicated_server_networkinterfacecontroller.py
@@ -60,6 +60,11 @@ def run_module():
     service_name = module.params['service_name']
     try:
         result = client.get('/dedicated/server/%s/networkInterfaceController?linkType=%s' % (service_name, link_type))
+        # XXX: This is a hack, would be better to detect what kind of server you are using:
+        # If there is no result, maybe you have a server with multiples network interfaces on the same link (2x public + 2x vrack), like HGR
+        # In this case, retry with public_lag/private_lag linkType
+        if not result:
+            result = client.get('/dedicated/server/%s/networkInterfaceController?linkType=%s_lag' % (service_name, link_type))
 
         module.exit_json(changed=False, msg=result)
     except APIError as api_error:

--- a/plugins/modules/dedicated_server_vrack.py
+++ b/plugins/modules/dedicated_server_vrack.py
@@ -86,6 +86,15 @@ def run_module():
             '/dedicated/server/%s/virtualNetworkInterface' % service_name,
             mode='vrack'
         )
+        # XXX: This is a hack, would be better to detect what kind of server you are using:
+        # If there is no result, maybe you have a server with multiples network interfaces on the same link (2x public + 2x vrack), like HGR
+        # In this case, retry with vrack_aggregation mode
+        if not result:
+            result = client.get(
+                '/dedicated/server/%s/virtualNetworkInterface' % service_name,
+                mode='vrack_aggregation'
+            )
+
     except APIError as api_error:
         module.fail_json(
             msg="Failed to call OVH API: {0}".format(api_error))


### PR DESCRIPTION
- For example on new HGR-SDS-2 instance, there are 2x public + 2x
  private interfaces (ready for link aggregations)
- Simply add a fallback to try the "aggregation" route on the API in
  case of empty answer on classic call