### PR TITLE
Add public_cloud_instance_delete module

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ public_cloud_flavorid_info
 public_cloud_imageid_info
 public_cloud_instance_info
 public_cloud_instance
+public_cloud_instance_delete
 public_cloud_monthly_billing
 public_cloud_block_storage_instance
 public_cloud_block_storage

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -7,7 +7,7 @@ namespace: synthesio
 name: ovh
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 5.3.0
+version: 5.3.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/plugins/modules/public_cloud_instance_delete.py
+++ b/plugins/modules/public_cloud_instance_delete.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: public_cloud_instance_delete
 short_description: Manage OVH API for public cloud instance deletion
@@ -28,24 +28,28 @@ options:
     region:
         required: true
         description:
-            - The region where to deploy the instance
-'''
+            - The region where the instance is deployed
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 - name: "Delete instance of {{ inventory_hostname }} on public cloud OVH"
   synthesio.ovh.public_cloud_instance_delete:
     name: "{{ inventory_hostname }}"
     service_name: "{{ service_name }}"
     region: "{{ region }}"
   delegate_to: localhost
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    ovh_api_connect,
+    ovh_argument_spec,
+)
 
 try:
     from ovh.exceptions import APIError
+
     HAS_OVH = True
 except ImportError:
     HAS_OVH = False
@@ -53,36 +57,39 @@ except ImportError:
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        name=dict(required=True),
-        service_name=dict(required=True),
-        region=dict(required=True)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(
+            name=dict(required=True),
+            service_name=dict(required=True),
+            region=dict(required=True),
+        )
     )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     client = ovh_api_connect(module)
 
-    name = module.params['name']
-    service_name = module.params['service_name']
+    name = module.params["name"]
+    service_name = module.params["service_name"]
+    region = module.params["region"]
     try:
-        instances_list = client.get('/cloud/project/%s/instance' % (service_name),
-                                    region=region)
+        instances_list = client.get(
+            "/cloud/project/%s/instance" % (service_name), region=region
+        )
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
     for i in instances_list:
 
-        if i['name'] == name:
-            instance_id = i['id']
-            instance_details = client.get('/cloud/project/%s/instance/%s' % (service_name, instance_id))
+        if i["name"] == name:
+            instance_id = i["id"]
+            instance_details = client.get(
+                "/cloud/project/%s/instance/%s" % (service_name, instance_id)
+            )
 
     try:
-        result = client.delete('/cloud/project/%s/instance/%s' % (service_name, instance_id))
-
-        module.exit_json(changed=True, **result)
+        result = client.delete(
+            "/cloud/project/%s/instance/%s" % (service_name, instance_id)
+        )
+        module.exit_json(changed=True)
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
@@ -91,5 +98,5 @@ def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/public_cloud_instance_delete.py
+++ b/plugins/modules/public_cloud_instance_delete.py
@@ -25,6 +25,10 @@ options:
         required: true
         description:
             - The service_name
+    region:
+        required: true
+        description:
+            - The region where to deploy the instance
 '''
 
 EXAMPLES = '''
@@ -32,6 +36,7 @@ EXAMPLES = '''
   synthesio.ovh.public_cloud_instance_delete:
     name: "{{ inventory_hostname }}"
     service_name: "{{ service_name }}"
+    region: "{{ region }}"
   delegate_to: localhost
 '''
 
@@ -50,7 +55,8 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         name=dict(required=True),
-        service_name=dict(required=True)
+        service_name=dict(required=True),
+        region=dict(required=True)
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/public_cloud_instance_delete.py
+++ b/plugins/modules/public_cloud_instance_delete.py
@@ -13,7 +13,7 @@ module: public_cloud_instance_delete
 short_description: Manage OVH API for public cloud instance deletion
 description:
     - This module manage the deletion of an instance on OVH public Cloud
-author: atrawog@dorgeln.org
+author: Andreas Trawoeger <atrawog@dorgeln.org>
 requirements:
     - ovh >= 0.5.0
 options:
@@ -31,6 +31,7 @@ EXAMPLES = '''
 - name: "Delete instance of {{ inventory_hostname }} on public cloud OVH"
   synthesio.ovh.public_cloud_instance_delete:
     name: "{{ inventory_hostname }}"
+    service_name: "{{ service_name }}"
   delegate_to: localhost
 '''
 
@@ -49,6 +50,7 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         name=dict(required=True),
+        service_name=dict(required=True)
     ))
 
     module = AnsibleModule(

--- a/plugins/modules/public_cloud_instance_delete.py
+++ b/plugins/modules/public_cloud_instance_delete.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_delete
+short_description: Manage OVH API for public cloud instance deletion
+description:
+    - This module manage the deletion of an instance on OVH public Cloud
+author: atrawog@dorgeln.org
+requirements:
+    - ovh >= 0.5.0
+options:
+    name:
+        required: true
+        description:
+            - The instance name to delete
+    service_name:
+        required: true
+        description:
+            - The service_name
+'''
+
+EXAMPLES = '''
+- name: "Delete instance of {{ inventory_hostname }} on public cloud OVH"
+  synthesio.ovh.public_cloud_instance_delete:
+    name: "{{ inventory_hostname }}"
+  delegate_to: localhost
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        name=dict(required=True),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    name = module.params['name']
+    service_name = module.params['service_name']
+    try:
+        instances_list = client.get('/cloud/project/%s/instance' % (service_name),
+                                    region=region)
+    except APIError as api_error:
+        module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+    for i in instances_list:
+
+        if i['name'] == name:
+            instance_id = i['id']
+            instance_details = client.get('/cloud/project/%s/instance/%s' % (service_name, instance_id))
+
+    try:
+        result = client.delete('/cloud/project/%s/instance/%s' % (service_name, instance_id))
+
+        module.exit_json(changed=True, **result)
+    except APIError as api_error:
+        module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This PR adds a public_cloud_instance_delete module for deleting existing cloud instances.

An alternative implementation would be to add a state flag to public_cloud_instance and use `state: absent` to delete an instance. A state flag would be pretty simple to implement, but it would require to make a lot of parameters in public_cloud_instance optional, because the aren't required for instance deletion.
 