### PR TITLE
New modules for public cloud APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,18 @@ dedicated_server_vrack
 domain
 installation_template
 ip_reverse
-public_cloud_flavorid_info
-public_cloud_imageid_info
-public_cloud_instance_info
-public_cloud_instance
-public_cloud_monthly_billing
 public_cloud_block_storage_instance
 public_cloud_block_storage
+public_cloud_failover_ip_info
+public_cloud_flavorid_info
+public_cloud_imageid_info
+public_cloud_instance
+public_cloud_instance_failover_ip
+public_cloud_instance_info
+public_cloud_instance_info_by_name
+public_cloud_instance_vrack
+public_cloud_monthly_billing
+public_cloud_project_info
 ```
 
 You can read the documentation of every modules with `ansible-doc synthesio.ovh.$modules`

--- a/README.md
+++ b/README.md
@@ -40,9 +40,12 @@ public_cloud_instance
 public_cloud_instance_failover_ip
 public_cloud_instance_info
 public_cloud_instance_info_by_name
-public_cloud_instance_vrack
+public_cloud_instance_netif_info
+public_cloud_instance_private_network
+public_cloud_instance_wait
 public_cloud_monthly_billing
 public_cloud_project_info
+public_cloud_ssh_key_info_by_name
 ```
 
 You can read the documentation of every modules with `ansible-doc synthesio.ovh.$modules`

--- a/plugins/modules/public_cloud_failover_ip_info.py
+++ b/plugins/modules/public_cloud_failover_ip_info.py
@@ -9,10 +9,10 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 ---
-module: public_cloud_instance_info
-short_description: Retrieve all info for a OVH public cloud instance
+module: public_cloud_failover_ip_info
+short_description: Retrieve all info for a OVH failover IP
 description:
-    - This module retrieves all info from a OVH public cloud instance
+    - This module retrieves all info from a OVH failover IP
 author: Synthesio SRE Team
 requirements:
     - ovh >= 0.5.0
@@ -20,17 +20,19 @@ options:
     service_name:
         required: true
         description: The OVH API service_name is  Public cloud project Id
-    instance_id:
+    fo_ip:
         required: true
-        description: The instance uuid
+        description:
+            - The fail-over IP
 
 '''
 
 EXAMPLES = '''
-synthesio.ovh.public_cloud_instance_info:
-  instance_id: "{{ instance_id }}"
+synthesio.ovh.public_cloud_failover_ip_info:
+  fo_ip: "{{ fo_ip }}"
   service_name: "{{ service_name }}"
 delegate_to: localhost
+register: fo_ip_id
 '''
 
 RETURN = ''' # '''
@@ -48,7 +50,7 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         service_name=dict(required=True),
-        instance_id=dict(required=True)
+        fo_ip=dict(required=True)
     ))
 
     module = AnsibleModule(
@@ -57,14 +59,21 @@ def run_module():
     )
     client = ovh_api_connect(module)
 
-    instance_id = module.params['instance_id']
+    fo_ip = module.params['fo_ip']
     service_name = module.params['service_name']
-    try:
-        result = client.get('/cloud/project/%s/instance/%s' % (service_name, instance_id))
 
-        module.exit_json(changed=False, **result)
+    fo_ips_list = []
+    try:
+        fo_ips_list = client.get('/cloud/project/{0}/ip/failover'.format(service_name))
     except APIError as api_error:
-        module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+        module.fail_json(msg="Error getting failover ips list: {0}".format(api_error))
+
+    for ip_data in fo_ips_list:
+
+        if ip_data['ip'] == fo_ip:
+            module.exit_json(changed=False, **ip_data)
+
+    module.fail_json(msg="Error: could not find given fail-over IP {0} in {1}".format(fo_ip, fo_ips_list))
 
 
 def main():

--- a/plugins/modules/public_cloud_failover_ip_info.py
+++ b/plugins/modules/public_cloud_failover_ip_info.py
@@ -13,7 +13,7 @@ module: public_cloud_failover_ip_info
 short_description: Retrieve all info for a OVH failover IP
 description:
     - This module retrieves all info from a OVH failover IP
-author: Synthesio SRE Team
+author: Article714 (M. Piriou, C. Guychard)
 requirements:
     - ovh >= 0.5.0
 options:

--- a/plugins/modules/public_cloud_instance_failover_ip.py
+++ b/plugins/modules/public_cloud_instance_failover_ip.py
@@ -94,11 +94,9 @@ def run_module():
         is_already_attached = True
 
     # Attach or detach
-    
     if state == 'present':
         if not is_already_attached:
             try:
-                
                 attach_result = client.post(
                     '/cloud/project/{0}/ip/failover/{1}/attach'.format(service_name, fo_ip_id), instanceId=instance_id)
 
@@ -107,18 +105,17 @@ def run_module():
 
             except APIError as api_error:
                 module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
-        
+
         module.exit_json( msg="Fail-over IP {} interface already exists on instance {}".format(
-                                    fo_ip_id, instance_id), changed=False)    
-                                 
+                                    fo_ip_id, instance_id), changed=False)
+
     else:
         if is_already_attached:
             module.fail_json(msg="NOT SUPPORTED BY API YET: Do no know how to remove fo_ip_id from instance... ")
 
         module.exit_json( msg="Fail-over IP {} interface does not exist on instance {}".format(
-                                    fo_ip_id, instance_id), changed=False)    
-                           
-                           
+                                    fo_ip_id, instance_id), changed=False)
+
 def main():
     run_module()
 

--- a/plugins/modules/public_cloud_instance_failover_ip.py
+++ b/plugins/modules/public_cloud_instance_failover_ip.py
@@ -1,0 +1,127 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_failover_ip
+short_description: Manage OVH API for public cloud: attach fail-over IP to instance
+description:
+    - This module manage the attachment of  fail-over IP to an OVH public Cloud instance
+author: Article714 (M. Piriou, C. Guychard)
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description:
+            - The named/id of the project, that can be obtained using public_cloud_project_info module
+    instance_id:
+        required: true
+        description:
+            - The instance name
+    fo_ip_id:
+        required: true
+        description:
+            - The id of the fail-over IP id
+    state:
+        required: false
+        default: present
+        choices: ['present','absent']
+        description: Indicate the desired state of vrack
+'''
+
+EXAMPLES = '''
+- name: "Attach an fail-over IP to {{ instance_id }} on public cloud OVH"
+  synthesio.ovh.public_cloud_instance_failover_ip:
+    instance_id: "{{ instance_id }}"
+    service_name: "{{ service_name }}"
+    fo_ip_id: "{{ fo_ip_id }}"
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        fo_ip_id=dict(required=True),
+        instance_id=dict(required=False),
+        state=dict(choices=['present', 'absent'], default='present'),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+    service_name = module.params['service_name']
+    fo_ip_id = module.params['fo_ip_id']
+    instance_id= module.params['instance_id']
+    state = module.params['state']
+
+
+    if module.check_mode:
+        module.exit_json(
+            msg="successfully (a)(de)tached ({}) IP {} to/from instance {}/{} - (dry run mode)".format(
+                fo_ip_id , state, instance_id, service_name ),
+            changed=True)
+
+    # get data about ip
+    ip_data = None
+    try:
+        ip_data = client.get('/cloud/project/{0}/ip/failover/{1}'.format(service_name, fo_ip_id))
+    except APIError as api_error:
+        module.fail_json(msg="Error getting failover ip data list: {0}".format(api_error))
+
+    is_already_attached = False
+    if ip_data and ip_data["routedTo"] == instance_id:
+        is_already_attached = True
+
+    # Attach or detach
+    
+    if state == 'present':
+        if not is_already_attached:
+            try:
+                
+                attach_result = client.post(
+                    '/cloud/project/{0}/ip/failover/{1}/attach'.format(service_name, fo_ip_id), instanceId=instance_id)
+
+                module.exit_json( msg="Fail-over IP {} has been attached to instance {}/{}".format(
+                                    fo_ip_id, instance_id, service_name), result= attach_result, changed=True)
+
+            except APIError as api_error:
+                module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+        
+        module.exit_json( msg="Fail-over IP {} interface already exists on instance {}".format(
+                                    fo_ip_id, instance_id), changed=False)    
+                                 
+    else:
+        if is_already_attached:
+            module.fail_json(msg="NOT SUPPORTED BY API YET: Do no know how to remove fo_ip_id from instance... ")
+
+        module.exit_json( msg="Fail-over IP {} interface does not exist on instance {}".format(
+                                    fo_ip_id, instance_id), changed=False)    
+                           
+                           
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_instance_failover_ip.py
+++ b/plugins/modules/public_cloud_instance_failover_ip.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: public_cloud_instance_failover_ip
 short_description: Manage OVH API for public cloud: attach fail-over IP to instance
@@ -35,22 +35,26 @@ options:
         default: present
         choices: ['present','absent']
         description: Indicate the desired state of vrack
-'''
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 - name: "Attach an fail-over IP to {{ instance_id }} on public cloud OVH"
   synthesio.ovh.public_cloud_instance_failover_ip:
     instance_id: "{{ instance_id }}"
     service_name: "{{ service_name }}"
     fo_ip_id: "{{ fo_ip_id }}"
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    ovh_api_connect,
+    ovh_argument_spec,
+)
 
 try:
     from ovh.exceptions import APIError
+
     HAS_OVH = True
 except ImportError:
     HAS_OVH = False
@@ -58,67 +62,91 @@ except ImportError:
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        service_name=dict(required=True),
-        fo_ip_id=dict(required=True),
-        instance_id=dict(required=False),
-        state=dict(choices=['present', 'absent'], default='present'),
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(
+            service_name=dict(required=True),
+            fo_ip_id=dict(required=True),
+            instance_id=dict(required=False),
+            state=dict(choices=["present", "absent"], default="present"),
+        )
     )
-    client = ovh_api_connect(module)
-    service_name = module.params['service_name']
-    fo_ip_id = module.params['fo_ip_id']
-    instance_id= module.params['instance_id']
-    state = module.params['state']
 
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+    client = ovh_api_connect(module)
+    service_name = module.params["service_name"]
+    fo_ip_id = module.params["fo_ip_id"]
+    instance_id = module.params["instance_id"]
+    state = module.params["state"]
 
     if module.check_mode:
         module.exit_json(
             msg="successfully (a)(de)tached ({}) IP {} to/from instance {}/{} - (dry run mode)".format(
-                fo_ip_id , state, instance_id, service_name ),
-            changed=True)
+                fo_ip_id, state, instance_id, service_name
+            ),
+            changed=True,
+        )
 
     # get data about ip
     ip_data = None
     try:
-        ip_data = client.get('/cloud/project/{0}/ip/failover/{1}'.format(service_name, fo_ip_id))
+        ip_data = client.get(
+            "/cloud/project/{0}/ip/failover/{1}".format(service_name, fo_ip_id)
+        )
     except APIError as api_error:
-        module.fail_json(msg="Error getting failover ip data list: {0}".format(api_error))
+        module.fail_json(
+            msg="Error getting failover ip data list: {0}".format(api_error)
+        )
 
     is_already_attached = False
     if ip_data and ip_data["routedTo"] == instance_id:
         is_already_attached = True
 
     # Attach or detach
-    if state == 'present':
+    if state == "present":
         if not is_already_attached:
             try:
                 attach_result = client.post(
-                    '/cloud/project/{0}/ip/failover/{1}/attach'.format(service_name, fo_ip_id), instanceId=instance_id)
+                    "/cloud/project/{0}/ip/failover/{1}/attach".format(
+                        service_name, fo_ip_id
+                    ),
+                    instanceId=instance_id,
+                )
 
-                module.exit_json( msg="Fail-over IP {} has been attached to instance {}/{}".format(
-                                    fo_ip_id, instance_id, service_name), result= attach_result, changed=True)
+                module.exit_json(
+                    msg="Fail-over IP {} has been attached to instance {}/{}".format(
+                        fo_ip_id, instance_id, service_name
+                    ),
+                    result=attach_result,
+                    changed=True,
+                )
 
             except APIError as api_error:
                 module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
-        module.exit_json( msg="Fail-over IP {} interface already exists on instance {}".format(
-                                    fo_ip_id, instance_id), changed=False)
+        module.exit_json(
+            msg="Fail-over IP {} interface already exists on instance {}".format(
+                fo_ip_id, instance_id
+            ),
+            changed=False,
+        )
 
     else:
         if is_already_attached:
-            module.fail_json(msg="NOT SUPPORTED BY API YET: Do no know how to remove fo_ip_id from instance... ")
+            module.fail_json(
+                msg="NOT SUPPORTED BY API YET: Do no know how to remove fo_ip_id from instance... "
+            )
 
-        module.exit_json( msg="Fail-over IP {} interface does not exist on instance {}".format(
-                                    fo_ip_id, instance_id), changed=False)
+        module.exit_json(
+            msg="Fail-over IP {} interface does not exist on instance {}".format(
+                fo_ip_id, instance_id
+            ),
+            changed=False,
+        )
+
 
 def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/public_cloud_instance_info.py
+++ b/plugins/modules/public_cloud_instance_info.py
@@ -19,7 +19,7 @@ requirements:
 options:
     service_name:
         required: true
-        description: The OVH API service_name is  Public cloud project Id
+        description: The OVH API service_name is the Public cloud project Id
     instance_id:
         required: true
         description: The instance uuid

--- a/plugins/modules/public_cloud_instance_info_by_name.py
+++ b/plugins/modules/public_cloud_instance_info_by_name.py
@@ -1,0 +1,91 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_info_by_name
+short_description: Retrieve instance Id from a human-readable name
+description:
+    - This module retrieves instance Id from its human-readable name
+author: Article714 (C. Guychard)
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The OVH API service_name is  Public cloud project Id
+    instance_name:
+        required: true
+        description: The instance human-readable name
+    region:
+        required: true
+        description:
+            - The region where to deploy the instance
+
+'''
+
+EXAMPLES = '''
+synthesio.ovh.public_cloud_instance_info_by_name:
+  instance_name: "{{ instance_name }}"
+  service_name: "{{ service_name }}"
+  region: "{{ region_name }}"
+delegate_to: localhost
+'''
+
+RETURN = ''' Instance Id '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        instance_name=dict(required=True),
+        region=dict(required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    instance_name = module.params['instance_name']
+    service_name = module.params['service_name']
+    a_region = module.params['region']
+
+    try:
+        instances_list = client.get('/cloud/project/{0}/instance'.format(service_name,
+                            region=a_region))
+    except APIError as api_error:
+        module.fail_json(msg="Error getting instances list: {0}".format(api_error))
+
+    for inst in instances_list:
+
+        instanceId=None
+        if inst['name'] == instance_name:
+          instanceId = inst['id']
+        if instanceId:
+            module.exit_json(changed=False, **inst)
+
+    module.fail_json(changed=False, msg="Errort: Could not find instance named {0}".format(instance_name))
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_instance_info_by_name.py
+++ b/plugins/modules/public_cloud_instance_info_by_name.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: public_cloud_instance_info_by_name
 short_description: Retrieve instance Id from a human-readable name
@@ -28,22 +28,26 @@ options:
         description:
             - The region where to deploy the instance
 
-'''
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 synthesio.ovh.public_cloud_instance_info_by_name:
   instance_name: "{{ instance_name }}"
   service_name: "{{ service_name }}"
   region: "{{ region_name }}"
 delegate_to: localhost
-'''
+"""
 
-RETURN = ''' Instance Id '''
+RETURN = """ Instance Id """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    ovh_api_connect,
+    ovh_argument_spec,
+)
 
 try:
     from ovh.exceptions import APIError
+
     HAS_OVH = True
 except ImportError:
     HAS_OVH = False
@@ -51,41 +55,45 @@ except ImportError:
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        service_name=dict(required=True),
-        instance_name=dict(required=True),
-        region=dict(required=True)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(
+            service_name=dict(required=True),
+            instance_name=dict(required=True),
+            region=dict(required=True),
+        )
     )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     client = ovh_api_connect(module)
 
-    instance_name = module.params['instance_name']
-    service_name = module.params['service_name']
-    a_region = module.params['region']
+    instance_name = module.params["instance_name"]
+    service_name = module.params["service_name"]
+    a_region = module.params["region"]
 
     try:
-        instances_list = client.get('/cloud/project/{0}/instance'.format(service_name,
-                            region=a_region))
+        instances_list = client.get(
+            "/cloud/project/{0}/instance".format(service_name), region=a_region
+        )
     except APIError as api_error:
         module.fail_json(msg="Error getting instances list: {0}".format(api_error))
 
     for inst in instances_list:
 
-        instanceId=None
-        if inst['name'] == instance_name:
-          instanceId = inst['id']
+        instanceId = None
+        if inst["name"] == instance_name:
+            instanceId = inst["id"]
         if instanceId:
             module.exit_json(changed=False, **inst)
 
-    module.fail_json(changed=False, msg="Errort: Could not find instance named {0}".format(instance_name))
+    module.fail_json(
+        changed=False,
+        msg="Errort: Could not find instance named {0}".format(instance_name),
+    )
+
 
 def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/public_cloud_instance_netif_info.py
+++ b/plugins/modules/public_cloud_instance_netif_info.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_netif_info
+short_description: Retrieve network interface(s) info for a OVH public cloud instance
+description:
+    - This module queries OVH API to retrieve information about the netwwork interfaces attached to a Public Cloud Instance
+author: Article714 (C. Guychard)
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The OVH API service_name is the Public cloud project Id
+    instance_id:
+        required: true
+        description: The instance uuid
+
+'''
+
+EXAMPLES = '''
+synthesio.ovh.public_cloud_instance_netif_info:
+  instance_id: "{{ instance_id }}"
+  service_name: "{{ service_name }}"
+delegate_to: localhost
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        instance_id=dict(required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    instance_id = module.params['instance_id']
+    service_name = module.params['service_name']
+    try:
+        result = client.get('/cloud/project/%s/instance/%s/interface' % (service_name, instance_id))
+        if result:
+            module.exit_json(changed=False, **{'interfaces':result})
+        else:
+            module.exit_json(changed=False, **{'interfaces':[]})
+    except APIError as api_error:
+        module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_instance_netif_info.py
+++ b/plugins/modules/public_cloud_instance_netif_info.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: public_cloud_instance_netif_info
 short_description: Retrieve network interface(s) info for a OVH public cloud instance
@@ -24,21 +24,25 @@ options:
         required: true
         description: The instance uuid
 
-'''
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 synthesio.ovh.public_cloud_instance_netif_info:
   instance_id: "{{ instance_id }}"
   service_name: "{{ service_name }}"
 delegate_to: localhost
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    ovh_api_connect,
+    ovh_argument_spec,
+)
 
 try:
     from ovh.exceptions import APIError
+
     HAS_OVH = True
 except ImportError:
     HAS_OVH = False
@@ -46,25 +50,23 @@ except ImportError:
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        service_name=dict(required=True),
-        instance_id=dict(required=True)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(service_name=dict(required=True), instance_id=dict(required=True))
     )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     client = ovh_api_connect(module)
 
-    instance_id = module.params['instance_id']
-    service_name = module.params['service_name']
+    instance_id = module.params["instance_id"]
+    service_name = module.params["service_name"]
     try:
-        result = client.get('/cloud/project/%s/instance/%s/interface' % (service_name, instance_id))
+        result = client.get(
+            "/cloud/project/%s/instance/%s/interface" % (service_name, instance_id)
+        )
         if result:
-            module.exit_json(changed=False, **{'interfaces':result})
+            module.exit_json(changed=False, **{"interfaces": result})
         else:
-            module.exit_json(changed=False, **{'interfaces':[]})
+            module.exit_json(changed=False, **{"interfaces": []})
     except APIError as api_error:
         module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
@@ -73,5 +75,5 @@ def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/public_cloud_instance_private_network.py
+++ b/plugins/modules/public_cloud_instance_private_network.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_private_network
+short_description: Manage OVH API for public cloud attach private_network
+description:
+    - This module manage the attach of an private_network on OVH instance public Cloud
+author: Article714 (M. Piriou, C. Guychard)
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description:
+            - The OVH API service_name is  Public cloud project Id, that can be obtained using public_cloud_project_info module
+    instance_id:
+        required: true
+        description:
+            - The instance name
+    private_network:
+        required: true
+        description:
+            - The id of the private_network
+    state:
+        required: false
+        default: present
+        choices: ['present','absent']
+        description: Indicate the desired state of private_network
+'''
+
+EXAMPLES = '''
+- name: "Attach a private_network to instance {{ instance_id }} on public cloud OVH"
+  synthesio.ovh.public_cloud_instance_private_network:
+    instance_id: "{{ instance_id }}"
+    service_name: "{{ service_name }}"
+    private_network: "{{ private_network }}"
+    state: present
+'''
+
+RETURN = ''' # '''
+
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        state=dict(choices=['present', 'absent'], default='present'),
+        instance_id=dict(required=True),
+        private_network=dict(required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    service_name = module.params['service_name']
+    private_network = module.params['private_network']
+    instance_id= module.params['instance_id']
+    state = module.params['state']
+
+    if module.check_mode:
+        module.exit_json(
+            msg="{}/{} successfully configured ({}) on  private_network {} - (dry run mode)".format(
+                instance_id,service_name , state, private_network ),
+            changed=True)
+
+
+    is_already_registered = False   
+    private_network_if=None
+
+    # list existing interfaces
+    try:
+        interfaces_list = client.get(
+                '/cloud/project/{0}/instance/{1}/interface'.format(service_name, instance_id))
+        
+        for netif in interfaces_list:
+            if netif['networkId'] == private_network:
+                is_already_registered=True
+                private_network_if = netif
+
+    except APIError as api_error:
+        module.fail_json(msg="Failed to get interfaces list: {0}".format(api_error))
+        
+    # Attach or detach
+    
+    if state == 'present':
+        if not is_already_registered:
+            try:
+                attach_result = client.post(
+                    '/cloud/project/{0}/instance/{1}/interface'.format(service_name, instance_id), networkId=private_network)
+                module.exit_json(changed=True, **attach_result)
+
+                module.exit_json( msg="private_network {} interface has been added to instance {}".format(
+                                    private_network, instance_id), result= attach_result, changed=True)
+
+            except APIError as api_error:
+                module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
+
+        module.exit_json( msg="private_network {} interface already exists on instance {}".format(
+                                    private_network, instance_id), changed=False)    
+                                 
+    else:
+        if is_already_registered:
+            try:
+                detach_result = client.delete(
+                    '/cloud/project/{0}/instance/{1}/interface/{2}'.format(service_name, instance_id, private_network_if['id']))
+
+                module.exit_json( msg="private_network {} interface has been deleted from instance {}".format(
+                                    private_network, instance_id), result= detach_result,  changed=True)
+
+            except APIError as api_error:
+                module.fail_json(msg="Failed to remove private_network interface: {0}".format(api_error))
+
+        module.exit_json( msg="private_network {} interface does not exist on instance {}".format(
+                                    private_network, instance_id), changed=False)    
+                           
+
+    module.fail_json( msg="do not know how to deal with private_network information", changed=False)          
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_instance_private_network.py
+++ b/plugins/modules/public_cloud_instance_private_network.py
@@ -69,7 +69,7 @@ def run_module():
         service_name=dict(required=True),
         state=dict(choices=['present', 'absent'], default='present'),
         instance_id=dict(required=True),
-        private_network=dict(required=True),
+        private_network_id=dict(required=True),
         static_ip=dict(required=False,default=None)
     ))
 

--- a/plugins/modules/public_cloud_instance_private_network.py
+++ b/plugins/modules/public_cloud_instance_private_network.py
@@ -1,14 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: public_cloud_instance_private_network
 short_description: Manage OVH API for public cloud attach private_network
@@ -39,9 +39,9 @@ options:
         default: present
         choices: ['present','absent']
         description: Indicate the desired state of private_network
-'''
+"""
 
-EXAMPLES = '''
+EXAMPLES = """
 - name: "Attach a private_network to instance {{ instance_id }} on public cloud OVH"
   synthesio.ovh.public_cloud_instance_private_network:
     instance_id: "{{ instance_id }}"
@@ -49,15 +49,19 @@ EXAMPLES = '''
     private_network_id: "{{ private_network_id }}"
     static_ip: "{{ static_ip }}"
     state: present
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    ovh_api_connect,
+    ovh_argument_spec,
+)
 
 try:
     from ovh.exceptions import APIError
+
     HAS_OVH = True
 except ImportError:
     HAS_OVH = False
@@ -65,93 +69,131 @@ except ImportError:
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        service_name=dict(required=True),
-        state=dict(choices=['present', 'absent'], default='present'),
-        instance_id=dict(required=True),
-        private_network_id=dict(required=True),
-        static_ip=dict(required=False,default=None)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(
+            service_name=dict(required=True),
+            state=dict(choices=["present", "absent"], default="present"),
+            instance_id=dict(required=True),
+            private_network_id=dict(required=True),
+            static_ip=dict(required=False, default=None),
+        )
     )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     client = ovh_api_connect(module)
 
-    service_name = module.params['service_name']
-    private_network_id = module.params['private_network_id']
-    static_ip = module.params['static_ip']
-    instance_id= module.params['instance_id']
-    state = module.params['state']
+    service_name = module.params["service_name"]
+    private_network_id = module.params["private_network_id"]
+    static_ip = module.params["static_ip"]
+    instance_id = module.params["instance_id"]
+    state = module.params["state"]
 
     if module.check_mode:
         module.exit_json(
             msg="{}/{} successfully configured ({}) on  private_network {} - (dry run mode)".format(
-                instance_id,service_name , state, private_network_id ),
-            changed=True)
-
+                instance_id, service_name, state, private_network_id
+            ),
+            changed=True,
+        )
 
     is_already_registered = False
-    private_network_if=None
+    private_network_if = None
 
     # list existing interfaces
     try:
         interfaces_list = client.get(
-                '/cloud/project/{0}/instance/{1}/interface'.format(service_name, instance_id))
+            "/cloud/project/{0}/instance/{1}/interface".format(
+                service_name, instance_id
+            )
+        )
 
         for netif in interfaces_list:
-            if netif['networkId'] == private_network_id:
-                is_already_registered=True
+            if netif["networkId"] == private_network_id:
+                is_already_registered = True
                 private_network_if = netif
 
     except APIError as api_error:
         module.fail_json(msg="Failed to get interfaces list: {0}".format(api_error))
 
     # Attach or detach
-    if state == 'present':
+    if state == "present":
         if not is_already_registered:
             try:
                 if static_ip:
                     attach_result = client.post(
-                        '/cloud/project/{0}/instance/{1}/interface'.format(service_name, instance_id), networkId=private_network_id, ip=static_ip)
+                        "/cloud/project/{0}/instance/{1}/interface".format(
+                            service_name, instance_id
+                        ),
+                        networkId=private_network_id,
+                        ip=static_ip,
+                    )
                     module.exit_json(changed=True, **attach_result)
                 else:
                     attach_result = client.post(
-                        '/cloud/project/{0}/instance/{1}/interface'.format(service_name, instance_id), networkId=private_network_id)
+                        "/cloud/project/{0}/instance/{1}/interface".format(
+                            service_name, instance_id
+                        ),
+                        networkId=private_network_id,
+                    )
                     module.exit_json(changed=True, **attach_result)
 
-                module.exit_json( msg="private_network {} interface has been added to instance {}".format(
-                                    private_network_id, instance_id), result= attach_result, changed=True)
+                module.exit_json(
+                    msg="private_network {} interface has been added to instance {}".format(
+                        private_network_id, instance_id
+                    ),
+                    result=attach_result,
+                    changed=True,
+                )
 
             except APIError as api_error:
                 module.fail_json(msg="Failed to call OVH API: {0}".format(api_error))
 
-        module.exit_json( msg="private_network {} interface already exists on instance {}".format(
-                                    private_network_id, instance_id), changed=False)
+        module.exit_json(
+            msg="private_network {} interface already exists on instance {}".format(
+                private_network_id, instance_id
+            ),
+            changed=False,
+        )
 
     else:
         if is_already_registered:
             try:
                 detach_result = client.delete(
-                    '/cloud/project/{0}/instance/{1}/interface/{2}'.format(service_name, instance_id, private_network_if['id']))
+                    "/cloud/project/{0}/instance/{1}/interface/{2}".format(
+                        service_name, instance_id, private_network_if["id"]
+                    )
+                )
 
-                module.exit_json( msg="private_network {} interface has been deleted from instance {}".format(
-                                    private_network_id, instance_id), result= detach_result,  changed=True)
+                module.exit_json(
+                    msg="private_network {} interface has been deleted from instance {}".format(
+                        private_network_id, instance_id
+                    ),
+                    result=detach_result,
+                    changed=True,
+                )
 
             except APIError as api_error:
-                module.fail_json(msg="Failed to remove private_network interface: {0}".format(api_error))
+                module.fail_json(
+                    msg="Failed to remove private_network interface: {0}".format(
+                        api_error
+                    )
+                )
 
-        module.exit_json( msg="private_network {} interface does not exist on instance {}".format(
-                                    private_network_id, instance_id), changed=False)
+        module.exit_json(
+            msg="private_network {} interface does not exist on instance {}".format(
+                private_network_id, instance_id
+            ),
+            changed=False,
+        )
 
-
-    module.fail_json( msg="do not know how to deal with private_network information", changed=False)
+    module.fail_json(
+        msg="do not know how to deal with private_network information", changed=False
+    )
 
 
 def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/public_cloud_instance_wait.py
+++ b/plugins/modules/public_cloud_instance_wait.py
@@ -49,11 +49,7 @@ delegate_to: localhost
 RETURN = ''' # '''
 
 from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
-from ansible.utils.display import Display
-from ansible import constants
 import time
-
-display = Display()
 
 try:
     from ovh.exceptions import APIError
@@ -67,9 +63,9 @@ def run_module():
     module_args.update(dict(
         service_name=dict(required=True),
         instance_id=dict(required=True),
-        max_retry=dict(required=False, default=30,type='int'),
-        sleep=dict(required=False, default=20,type='int'),
-        target_status=dict(required=False, default='ACTIVE',type='str')
+        max_retry=dict(required=False, default=30, type='int'),
+        sleep=dict(required=False, default=20, type='int'),
+        target_status=dict(required=False, default='ACTIVE', type='str')
     ))
 
     module = AnsibleModule(
@@ -85,7 +81,7 @@ def run_module():
     target_status = module.params['target_status']
 
     is_target_status = False
-    
+
     if module.check_mode:
         module.exit_json(msg="done - (dry run mode)", changed=False)
 
@@ -100,7 +96,7 @@ def run_module():
 
         except APIError as api_error:
             return module.fail_jsonl(msg="Failed to call OVH API: {0}".format(api_error))
-        
+
         if is_target_status:
             module.exit_json(changed=True, **result)
 

--- a/plugins/modules/public_cloud_instance_wait.py
+++ b/plugins/modules/public_cloud_instance_wait.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: public_cloud_instance_wait
+short_description: Wait for an Public Cloud Instance to become active
+description:
+    - Wait until the public cloud instance installation is done (status == active)
+    - Can be used to wait before running next task in your playbook
+author: Synthesio SRE Team
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The OVH API service_name is  Public cloud project Id
+    instance_id:
+        required: true
+        description: The instance uuid
+    target_status:
+        required: true
+        description: target status to wait for
+        default: ACTIVE
+    max_retry:
+        required: false
+        description: Number of retries
+        default: 30
+    sleep:
+        required: false
+        description: Time to sleep between retries
+        default: 20
+
+'''
+
+EXAMPLES = '''
+synthesio.ovh.public_cloud_instance_wait:
+  instance_id: "{{ instance_id }}"
+  service_name: "{{ service_name }}"
+delegate_to: localhost
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible.utils.display import Display
+from ansible import constants
+import time
+
+display = Display()
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        instance_id=dict(required=True),
+        max_retry=dict(required=False, default=30,type='int'),
+        sleep=dict(required=False, default=20,type='int'),
+        target_status=dict(required=False, default='ACTIVE',type='str')
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    instance_id = module.params['instance_id']
+    service_name = module.params['service_name']
+    max_retry = module.params['max_retry']
+    sleep = module.params['sleep']
+    target_status = module.params['target_status']
+
+    is_target_status = False
+    
+    if module.check_mode:
+        module.exit_json(msg="done - (dry run mode)", changed=False)
+
+    for i in range(1, int(max_retry)):
+
+        result = None
+        try:
+            result = client.get('/cloud/project/%s/instance/%s' % (service_name, instance_id))
+
+            if result and 'status' in result:
+                is_target_status = (result['status'] == target_status)
+
+        except APIError as api_error:
+            return module.fail_jsonl(msg="Failed to call OVH API: {0}".format(api_error))
+        
+        if is_target_status:
+            module.exit_json(changed=True, **result)
+
+        time.sleep(float(sleep))
+
+    module.fail_json(msg="Max wait time reached, about %i x %i seconds" % (i, int(sleep)))
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_project_info.py
+++ b/plugins/modules/public_cloud_project_info.py
@@ -55,7 +55,6 @@ def run_module():
     client = ovh_api_connect(module)
 
     project_name = module.params['project_name']
-  
 
     try:
         projects_list = client.get('/cloud/project')
@@ -67,11 +66,11 @@ def run_module():
             proj_info = client.get('/cloud/project/%s' % proj_id)
         except APIError as api_error:
             module.fail_json(msg="Error getting project info: {0}".format(api_error))
-            
+
         if proj_info['description'] == project_name:
             break
 
-    if proj_info:                    
+    if proj_info:
         module.exit_json(changed=True, **proj_info)
 
 

--- a/plugins/modules/public_cloud_project_info.py
+++ b/plugins/modules/public_cloud_project_info.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: public_cloud_project_info
+short_description: Get OVH Public cloud project information
+description:
+    - This module retrieves information from Public Cloud Project using human-readble project name (description)
+author: Article714 (C. Guychard)
+requirements:
+    - ovh >= 0.5.0
+options:
+    project_name:
+        required: true
+        description:
+            - The project human-readable name
+'''
+
+EXAMPLES = '''
+- name: "Get info on OVH public cloud project {{ name }} "
+  synthesio.ovh.public_cloud_project_info:
+    project_name: "{{ name }}"
+'''
+
+RETURN = ''' All Project information '''
+
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        project_name=dict(required=True),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    project_name = module.params['project_name']
+  
+
+    try:
+        projects_list = client.get('/cloud/project')
+    except APIError as api_error:
+        module.fail_json(msg="Error getting projects list: {0}".format(api_error))
+
+    for proj_id in projects_list:
+        try:
+            proj_info = client.get('/cloud/project/%s' % proj_id)
+        except APIError as api_error:
+            module.fail_json(msg="Error getting project info: {0}".format(api_error))
+            
+        if proj_info['description'] == project_name:
+            break
+
+    if proj_info:                    
+        module.exit_json(changed=True, **proj_info)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/public_cloud_ssh_key_info_by_name.py
+++ b/plugins/modules/public_cloud_ssh_key_info_by_name.py
@@ -12,9 +12,9 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: public_cloud_project_info
-short_description: Get OVH Public cloud project SSH Keys information
+short_description: Get OVH Public cloud project SSH Key information
 description:
-    - This module retrieves SSH Keys information from Public Cloud Project using a human readable ssh name (name)
+    - This module retrieves SSH Key information from Public Cloud Project using a human readable ssh name (name)
 author: Article714 (C. Guychard)
 requirements:
     - ovh >= 0.5.0
@@ -25,7 +25,7 @@ options:
             - The ID of project
     ssh_name:
         required: true
-        description!
+        description:
             - The SSH Keys humane-readable name
 '''
 

--- a/plugins/modules/public_cloud_ssh_key_info_by_name.py
+++ b/plugins/modules/public_cloud_ssh_key_info_by_name.py
@@ -1,4 +1,3 @@
-
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
@@ -64,7 +63,6 @@ def run_module():
     ssh_key_name = module.params['ssh_key_name']
     service_name = module.params['service_name']
 
-
     key_ssh_list = []
     try:
         key_ssh_list = client.get('/cloud/project/{0}/sshkey'.format(service_name))
@@ -77,7 +75,6 @@ def run_module():
             module.exit_json(changed=False, **ssh_data)
 
     module.fail_json(msg="Error: could not find given SSH Key name {0} in {1}".format(ssh_key_name, key_ssh_list))
-
 
 
 def main():

--- a/plugins/modules/public_cloud_ssh_key_info_by_name.py
+++ b/plugins/modules/public_cloud_ssh_key_info_by_name.py
@@ -23,7 +23,7 @@ options:
         required: true
         description:
             - The ID of project
-    ssh_name:
+    ssh_key_name:
         required: true
         description:
             - The SSH Keys humane-readable name
@@ -33,7 +33,7 @@ EXAMPLES = '''
 - name: "Get info on OVH public cloud SSH key {{ name }} "
   synthesio.ovh.public_cloud_project_info:
     project_name: "{{ id_project }}"
-    ssh_name: "{{ ssh_name }}"
+    ssh_key_name: "{{ ssh_key_name }}"
 '''
 
 RETURN = ''' All SSH Key information '''
@@ -51,7 +51,7 @@ except ImportError:
 def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
-        ssh_name=dict(required=True),
+        ssh_key_name=dict(required=True),
         service_name=dict(required=True)
     ))
 
@@ -61,7 +61,7 @@ def run_module():
     )
     client = ovh_api_connect(module)
 
-    ssh_name = module.params['ssh_name']
+    ssh_key_name = module.params['ssh_key_name']
     service_name = module.params['service_name']
 
 
@@ -73,10 +73,10 @@ def run_module():
 
     for ssh_data in key_ssh_list:
 
-        if ssh_data['name'] == ssh_name:
+        if ssh_data['name'] == ssh_key_name:
             module.exit_json(changed=False, **ssh_data)
 
-    module.fail_json(msg="Error: could not find given SSH Key name {0} in {1}".format(ssh_name, key_ssh_list))
+    module.fail_json(msg="Error: could not find given SSH Key name {0} in {1}".format(ssh_key_name, key_ssh_list))
 
 
 


### PR DESCRIPTION
New modules for the public cloud were added. They allow you to create a public cloud instance at OVH, to attach a private IP and a failover IP to a public cloud instance. Some of these modules also allow replacing the identifiers of variables (project id ...) by their names.

Here is the list of new additions:

public_cloud_failover_ip_info.py,
public_cloud_instance_failover_ip.py,
public_cloud_info_by_name.py,
public_cloud_instance_info.py,
public_cloud_instance_private_network.py,
public_cloud_inject_prooudy.py.
public_cloud_ssh_key_info_by_name.py

The README has been modified.