### PR TITLE
Fixed issue #38 with unsafe parsing of yaml file

### DIFF
--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -93,7 +93,7 @@ def run_module():
 
     src = template
     with open(src, 'r') as stream:
-        content = yaml.load(stream)
+        content = yaml.safe_load(stream)
     conf = {}
     for i, j in content.items():
         conf[i] = j


### PR DESCRIPTION
Very simple fix to avoid using deprecated yaml call