### PR TITLE
Add dedicated_server_boot_wait

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This collection provides the following modules:
 
 ```text
 dedicated_server_boot
+dedicated_server_boot_wait
 dedicated_server_display_name
 dedicated_server_info
 dedicated_server_install

--- a/plugins/modules/dedicated_server_boot_wait.py
+++ b/plugins/modules/dedicated_server_boot_wait.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = '''
+---
+module: dedicated_server_boot_wait
+short_description: Wait until the dedicated server hard reboot is done
+description:
+    - Wait until the dedicated server hard reboot is done
+    - Can be used to wait before running next task in your playbook
+author: Synthesio SRE Team
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: Ovh name of the server
+    max_retry:
+        required: false
+        description: Number of retry
+        default: 240
+    sleep:
+        required: false
+        description: Time to sleep between retries
+        default: 10
+
+'''
+
+EXAMPLES = '''
+- name: Wait until the dedicated server hard reboot is done
+  synthesio.ovh.dedicated_server_boot_wait:
+    service_name: "ns12345.ip-1-2-3.eu"
+    max_retry: "240"
+    sleep: "10"
+  delegate_to: localhost
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
+from ansible.utils.display import Display
+from ansible import constants
+import time
+
+display = Display()
+
+try:
+    from ovh.exceptions import APIError
+    HAS_OVH = True
+except ImportError:
+    HAS_OVH = False
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        max_retry=dict(required=False, default=240),
+        sleep=dict(required=False, default=10)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = ovh_api_connect(module)
+
+    service_name = module.params['service_name']
+    max_retry = module.params['max_retry']
+    sleep = module.params['sleep']
+
+    if module.check_mode:
+        module.exit_json(msg="done - (dry run mode)", changed=False)
+
+    for i in range(1, int(max_retry)):
+        # Messages cannot be displayed in real time (yet)
+        # https://github.com/ansible/proposals/issues/92
+        display.display("%i out of %i" %
+                        (i, int(max_retry)), constants.COLOR_VERBOSE,screen_only=True)
+        try:
+            tasklist = client.get(
+                '/dedicated/server/%s/task' % service_name,
+                function='hardReboot')
+            result = client.get(
+                '/dedicated/server/%s/task/%s' % (service_name, max(tasklist)))
+        except APIError as api_error:
+            return module.fail_jsonl(msg="Failed to call OVH API: {0}".format(api_error))
+
+        message = ""
+        # Get details in reboot progression
+        if "done" in result['status']:
+            module.exit_json(msg="{}: {}".format(result['status'], message), changed=False)
+        else:
+            message = result['status']
+
+        display.display("{}: {}".format(result['status'], message), constants.COLOR_VERBOSE)
+        time.sleep(float(sleep))
+    module.fail_json(msg="Max wait time reached, about %i x %i seconds" % (i, int(sleep)))
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/dedicated_server_boot_wait.py
+++ b/plugins/modules/dedicated_server_boot_wait.py
@@ -43,11 +43,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
-from ansible.utils.display import Display
-from ansible import constants
 import time
-
-display = Display()
 
 try:
     from ovh.exceptions import APIError
@@ -78,10 +74,6 @@ def run_module():
         module.exit_json(msg="done - (dry run mode)", changed=False)
 
     for i in range(1, int(max_retry)):
-        # Messages cannot be displayed in real time (yet)
-        # https://github.com/ansible/proposals/issues/92
-        display.display("%i out of %i" %
-                        (i, int(max_retry)), constants.COLOR_VERBOSE, screen_only=True)
         try:
             tasklist = client.get(
                 '/dedicated/server/%s/task' % service_name,
@@ -98,7 +90,6 @@ def run_module():
         else:
             message = result['status']
 
-        display.display("{}: {}".format(result['status'], message), constants.COLOR_VERBOSE)
         time.sleep(float(sleep))
     module.fail_json(msg="Max wait time reached, about %i x %i seconds" % (i, int(sleep)))
 

--- a/plugins/modules/dedicated_server_boot_wait.py
+++ b/plugins/modules/dedicated_server_boot_wait.py
@@ -81,7 +81,7 @@ def run_module():
         # Messages cannot be displayed in real time (yet)
         # https://github.com/ansible/proposals/issues/92
         display.display("%i out of %i" %
-                        (i, int(max_retry)), constants.COLOR_VERBOSE,screen_only=True)
+                        (i, int(max_retry)), constants.COLOR_VERBOSE, screen_only=True)
         try:
             tasklist = client.get(
                 '/dedicated/server/%s/task' % service_name,


### PR DESCRIPTION
This PR adds a dedicated_server_boot_wait module for waiting before doing other tasks.
It is based on dedicated_server_install_wait, maybe it would be better to add a generic "dedicated_server_task_wait" module to wait for any tasks..

Anyway i just needed this to do a customized install on my dedicated servers, without using dedicated_server_install.