### PR TITLE
INFRA-8337: Make module compatible with ansible-core 2.12+

### DIFF
--- a/plugins/modules/dedicated_server_install_wait.py
+++ b/plugins/modules/dedicated_server_install_wait.py
@@ -43,11 +43,7 @@ EXAMPLES = '''
 RETURN = ''' # '''
 
 from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import ovh_api_connect, ovh_argument_spec
-from ansible.utils.display import Display
-from ansible import constants
 import time
-
-display = Display()
 
 try:
     from ovh.exceptions import APIError
@@ -78,10 +74,6 @@ def run_module():
         module.exit_json(msg="done - (dry run mode)", changed=False)
 
     for i in range(1, int(max_retry)):
-        # Messages cannot be displayed in real time (yet)
-        # https://github.com/ansible/proposals/issues/92
-        display.display("%i out of %i" %
-                        (i, int(max_retry)), constants.COLOR_VERBOSE)
         try:
             tasklist = client.get(
                 '/dedicated/server/%s/task' % service_name,
@@ -105,7 +97,6 @@ def run_module():
             for progress in progress_status['progress']:
                 if progress["status"] == "doing":
                     message = progress['comment']
-        display.display("{}: {}".format(result['status'], message), constants.COLOR_VERBOSE)
         time.sleep(float(sleep))
     module.fail_json(msg="Max wait time reached, about %i x %i seconds" % (i, int(sleep)))
 


### PR DESCRIPTION
- Remove useless Display usage which is broken with ansible-core 2.12+, it should be moved in an action, but we can't use the feature, so remove it
- This fixes https://github.com/synthesio/infra-ovh-ansible-module/issues/48