### PR TITLE
Add meta/main.yml

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,0 +1,11 @@
+galaxy_info:
+  role_name: ovh
+  author: synthesio
+  description: An Ansible collection to talk with OVH API.
+  license: LICENSE
+  min_ansible_version: 2.11
+
+  galaxy_tags:
+    - cloud
+
+dependencies: []


### PR DESCRIPTION
If you wish to use requirements.yml with the following requirement

```
- name: synthesio.ovh
  src: git+https://github.com/synthesio/infra-ovh-ansible-module
```

then executing `ansible-galaxy install -r requirements.yml` fails with `[WARNING]: - synthesio.ovh was NOT installed successfully: this role does not appear to have a meta/main.yml file.`

This PR adds meta/main.yml enabling previously mentioned usage of requirements.yml.