### PR TITLE
installationTemplate: Remove property defaultLanguage to avoid error

### DIFF
--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -94,7 +94,6 @@ def run_module():
         "POST",
         '/me/installationTemplate',
         baseTemplateName=conf['baseTemplateName'],
-        defaultLanguage=conf['defaultLanguage'],
         name=conf['templateName']
     )
 

--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -103,9 +103,11 @@ def run_module():
             "postInstallationScriptLink": conf['postInstallationScriptLink'],
             "postInstallationScriptReturn": conf['postInstallationScriptReturn'],
             "sshKeyName": conf['sshKeyName'],
-            "useDistributionKernel": conf['useDistributionKernel']},
-        'defaultLanguage': conf['defaultLanguage'],
-        'templateName': conf['templateName']}
+            "useDistributionKernel": conf['useDistributionKernel']
+            },
+        'templateName': conf['templateName']
+        }
+
     client.wrap_call(
         "PUT",
         f"/me/installationTemplate/{conf['templateName']}",

--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -104,9 +104,9 @@ def run_module():
             "postInstallationScriptReturn": conf['postInstallationScriptReturn'],
             "sshKeyName": conf['sshKeyName'],
             "useDistributionKernel": conf['useDistributionKernel']
-            },
+        },
         'templateName': conf['templateName']
-        }
+    }
 
     client.wrap_call(
         "PUT",


### PR DESCRIPTION
__Deprecated, OVH API use language in userMetadata instead.__


Error returned `Some properties does not exist: defaultLanguage`

Refere to api [installationTemplate](https://eu.api.ovh.com/console/?section=%2Fme&branch=v1#post-/me/installationTemplate) and [templateName](https://eu.api.ovh.com/console/?section=%2Fme&branch=v1#put-/me/installationTemplate/-templateName-)