### PR TITLE
feat: add user_metadata to dedicated_server_install module

### DIFF
--- a/plugins/modules/vps_display_name.py
+++ b/plugins/modules/vps_display_name.py
@@ -60,19 +60,18 @@ def run_module():
 
     resource = {
         'displayName': display_name
-        }
+    }
 
     # Endpoint /vps/{service_name} retrieves (among others) the current value for displayName
 
-    get_result=client.wrap_call(
+    get_result = client.wrap_call(
         "GET",
         f"/vps/{service_name}",
         **resource
     )
 
     # Now check if the value is different and if necessary set it
-    
-    if getResult['displayName'] != display_name:
+    if get_result['displayName'] != display_name:
         client.wrap_call(
             "PUT",
             f"/vps/{service_name}",
@@ -85,6 +84,7 @@ def run_module():
         module.exit_json(
             msg="No change required to displayName {} for {} !".format(display_name, service_name),
             changed=False)
+
 
 def main():
     run_module()


### PR DESCRIPTION
This field allows to push metadata during the intallation
i.e.: The ssh public key can be pushed as shown in the example

It's been tested on my end and should not cause any breaking change as it's not a requiered field and has no impact if not provided