### PR TITLE
INFRA-9852: add ssh_key_name parameter to allow the use of registered ssh keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,23 +29,28 @@ dedicated_server_install
 dedicated_server_install_wait
 dedicated_server_monitoring
 dedicated_server_networkinterfacecontroller
+dedicated_server_rescuesshkey
 dedicated_server_terminate
 dedicated_server_vrack
 domain
 installation_template
-ip_move
 ip_info
+ip_move
 ip_reverse
+public_cloud_block_storage
+public_cloud_block_storage_instance
 public_cloud_flavorid_info
 public_cloud_imageid_info
-public_cloud_instance_info
 public_cloud_instance
 public_cloud_instance_delete
+public_cloud_instance_info
+public_cloud_instance_interface
 public_cloud_monthly_billing
-public_cloud_block_storage_instance
-public_cloud_block_storage
 public_cloud_object_storage
 public_cloud_object_storage_policy
+public_cloud_private_network_info
+vps_display_name
+vps_info
 ```
 
 You can read the documentation of every modules with `ansible-doc synthesio.ovh.$modules`

--- a/plugins/modules/dedicated_server_rescuesshkey.py
+++ b/plugins/modules/dedicated_server_rescuesshkey.py
@@ -20,16 +20,25 @@ options:
         required: true
         description: The service_name
     ssh_key:
-        required: true
+        required: false
         description: The ssh public key string
+    ssh_key_name:
+        required: false
+        description: The ssh public name registered in the API under `/me/sshKey` endpoint
 
 '''
 
 EXAMPLES = r'''
-- name: "Set the ssh key for access in rescue mode {{ service_name }}"
+- name: "Set the ssh key (by value) for access in rescue mode {{ service_name }}"
   synthesio.ovh.dedicated_server_rescuesshkey:
     service_name: "{{ service_name }}"
     ssh_key: "ssh-ed25519 [....]"
+  delegate_to: localhost
+
+- name: "Set the ssh key (by name) for access in rescue mode {{ service_name }}"
+  synthesio.ovh.dedicated_server_rescuesshkey:
+    service_name: "{{ service_name }}"
+    ssh_key_name: "mysshkeyname"
   delegate_to: localhost
 '''
 
@@ -42,7 +51,8 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         service_name=dict(required=True),
-        ssh_key=dict(required=True)
+        ssh_key=dict(required=False, default=None),
+        ssh_key_name=dict(required=False, default=None)
     ))
 
     module = AnsibleModule(
@@ -53,11 +63,19 @@ def run_module():
 
     service_name = module.params['service_name']
     ssh_key = module.params['ssh_key']
+    ssh_key_name = module.params['ssh_key_name']
+
+    if ssh_key is None and ssh_key_name is None:
+        module.exit_json(msg="You must specify one parameter, ssh_key or ssh_key_name", changed=True)
 
     if module.check_mode:
         module.exit_json(msg="Ssh key is set for {} - (dry run mode)".format(service_name), changed=True)
 
     server_state = client.wrap_call("GET", f"/dedicated/server/{service_name}")
+
+    # if both exists (ssh_key and ssh_key_name), priority is given to ssh_key_name and ssh_key is ignored
+    if ssh_key_name is not None:
+        ssh_key = client.wrap_call("GET", f"/me/sshKey/{ssh_key_name}")['key']
 
     if server_state['rescueSshKey'] == ssh_key:
         module.exit_json(msg="Ssh key is already set on {}".format(service_name), changed=False)


### PR DESCRIPTION
- Add ssh_key_name parameter to be able to retreive registered ssh keys
- Use ssh_key_name first if ssh_key_name and ssh_key both exist