### PR TITLE
INFRA-9859: update dedicated server boot option

### DIFF
--- a/plugins/modules/dedicated_server_boot.py
+++ b/plugins/modules/dedicated_server_boot.py
@@ -23,7 +23,7 @@ options:
     boot:
         required: true
         default: harddisk
-        choices: ['harddisk','rescue','rescue-customer']
+        choices: ['harddisk','rescue-customer','ipxe-shell','poweroff']
         description:
             - Which way you want to boot your dedicated server
     force_reboot:
@@ -53,7 +53,7 @@ def run_module():
     module_args = ovh_argument_spec()
     module_args.update(dict(
         service_name=dict(required=True),
-        boot=dict(required=True, choices=['harddisk', 'rescue', 'rescue-customer']),
+        boot=dict(required=True, choices=['harddisk', 'rescue-customer', 'ipxe-shell', 'poweroff']),
         force_reboot=dict(required=False, default=False, type='bool')
     ))
 
@@ -68,7 +68,7 @@ def run_module():
     force_reboot = module.params['force_reboot']
     changed = False
 
-    bootid = {'harddisk': 1, 'rescue': 1122, 'rescue-customer': 46371}
+    bootid = {'harddisk': 1, 'rescue-customer': 46371, 'ipxe-shell': 203323, 'poweroff': 95083}
     if module.check_mode:
         module.exit_json(
             msg="{} is now set to boot on {}. Reboot in progress... - (dry run mode)".format(service_name, boot),

--- a/plugins/modules/dedicated_server_install.py
+++ b/plugins/modules/dedicated_server_install.py
@@ -84,7 +84,7 @@ def run_module():
     user_metadata = module.params['user_metadata']
 
     if module.check_mode:
-        module.exit_json(msg="Installation in progress on {} as {} with template {} - (dry run mode)".format(service_name, hostname, template),
+        module.exit_json(msg=f"Installation in progress on {service_name} as {hostname} with template {template} - (dry run mode)",
                          changed=True)
 
     compatible_templates = client.wrap_call(
@@ -92,7 +92,7 @@ def run_module():
         f"/dedicated/server/{service_name}/install/compatibleTemplates"
     )
     if template not in compatible_templates["ovh"] and template not in compatible_templates["personal"]:
-        module.fail_json(msg="{} doesn't exist in compatibles templates".format(template))
+        module.fail_json(msg="f{template} doesn't exist in compatibles templates")
 
     details = {"details":
                {"language": "en",
@@ -110,7 +110,7 @@ def run_module():
         userMetadata=user_metadata,
     )
 
-    module.exit_json(msg="Installation in progress on {} as {} with template {}!".format(service_name, hostname, template), changed=True)
+    module.exit_json(msg=f"Installation in progress on {service_name} as {hostname} with template {template}!", changed=True)
 
 
 def main():


### PR DESCRIPTION
- remove rescue (legacy)
- add ipxe-shell and poweroff (formally 'power')

still use static mapping because rescue-customer and ipxe-shell are using the same bootType (rescue) on '/dedicated/server/{serviceName}/boot' API endpoint