### PR TITLE
INFRA-9916 remove ssh_key_name reference due to OVH API changes

### DIFF
--- a/plugins/modules/dedicated_server_install.py
+++ b/plugins/modules/dedicated_server_install.py
@@ -25,9 +25,6 @@ options:
     template:
         required: true
         description: template to use to spawn the server
-    ssh_key_name:
-        required: false
-        description: sshkey to deploy
     soft_raid_devices:
         required: false
         description: number of devices in the raid software
@@ -48,7 +45,6 @@ EXAMPLES = r'''
     template: "debian10_64"
     soft_raid_devices: "2"
     raid: "enabled"
-    ssh_key_name: "mysshkeyname"
     partition_scheme_name: "custom"
     user_metadata:
         - key: sshKey
@@ -67,7 +63,6 @@ def run_module():
         service_name=dict(required=True),
         hostname=dict(required=True),
         template=dict(required=True),
-        ssh_key_name=dict(required=False, default=None),
         soft_raid_devices=dict(required=False, default=None),
         partition_scheme_name=dict(required=False, default="default"),
         raid=dict(choices=['enabled', 'disabled'], default='enabled', required=False),
@@ -83,7 +78,6 @@ def run_module():
     service_name = module.params['service_name']
     hostname = module.params['hostname']
     template = module.params['template']
-    ssh_key_name = module.params['ssh_key_name']
     soft_raid_devices = module.params['soft_raid_devices']
     raid = module.params['raid']
     partition_scheme_name = module.params['partition_scheme_name']
@@ -108,7 +102,6 @@ def run_module():
     details = {"details":
                {"language": "en",
                 "customHostname": hostname,
-                "sshKeyName": ssh_key_name,
                 "softRaidDevices": soft_raid_devices,
                 "noRaid": no_raid}
                }

--- a/plugins/modules/installation_template.py
+++ b/plugins/modules/installation_template.py
@@ -102,7 +102,6 @@ def run_module():
             "customHostname": conf['customHostname'],
             "postInstallationScriptLink": conf['postInstallationScriptLink'],
             "postInstallationScriptReturn": conf['postInstallationScriptReturn'],
-            "sshKeyName": conf['sshKeyName'],
             "useDistributionKernel": conf['useDistributionKernel']
         },
         'templateName': conf['templateName']


### PR DESCRIPTION
OVH is removing ssh_key_name usage from it's API, we need to remove it from ovh-ansible module

https://bare-metal-servers.status-ovhcloud.com/incidents/w8l0x9b11qcm

Message from OVH API
```
Fails calling API (POST https://eu.api.ovh.com/1.0/dedicated/server/{serviceName}/install/start):
You are referring to a personal template that contains a sshKeyName parameter that will stop
working starting from the 10th of September 2024. Please fix your personal template and payload
now: https://ovh.to/ECDecxY or wait 60s and retry if you prefer to fix later
```

If you use custom templates, you need to delete them from OVH API if they exist.

Go to the endpoints `/me/installationTemplate` and `DEL /me/installationTemplate/{templateName}`