### PR TITLE
Jt/add dedicated server intervention

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ dedicated_server_display_name
 dedicated_server_info
 dedicated_server_install
 dedicated_server_install_wait
+dedicated_server_intervention
 dedicated_server_monitoring
 dedicated_server_networkinterfacecontroller
 dedicated_server_rescuesshkey

--- a/plugins/modules/dedicated_server_intervention.py
+++ b/plugins/modules/dedicated_server_intervention.py
@@ -18,7 +18,7 @@ requirements:
 options:
     service_name:
         required: true
-        description: The service_name
+        description: The service name
     state:
         required: true
         description: Indicate the desired state of intervention

--- a/plugins/modules/dedicated_server_intervention.py
+++ b/plugins/modules/dedicated_server_intervention.py
@@ -58,19 +58,19 @@ def run_module():
     state = module.params['state']
 
     if state == 'enabled':
-        noIntervention_bool = False
+        no_intervention_bool = False
     elif state == 'disabled':
-        noIntervention_bool = True
+        no_intervention_bool = True
 
     if module.check_mode:
         module.exit_json(msg="NoIntervention is now {} for {} - (dry run mode)".format(state, service_name), changed=True)
 
     server_state = client.wrap_call("GET", f"/dedicated/server/{service_name}")
 
-    if server_state['noIntervention'] == noIntervention_bool:
+    if server_state['noIntervention'] == no_intervention_bool:
         module.exit_json(msg="noIntervention is already {} on {}".format(state, service_name), changed=False)
 
-    client.wrap_call("PUT", f"/dedicated/server/{service_name}", noIntervention=noIntervention_bool)
+    client.wrap_call("PUT", f"/dedicated/server/{service_name}", noIntervention=no_intervention_bool)
 
     module.exit_json(msg="noIntervention is now {} on {}".format(state, service_name), changed=True)
 

--- a/plugins/modules/dedicated_server_intervention.py
+++ b/plugins/modules/dedicated_server_intervention.py
@@ -1,0 +1,83 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils.basic import AnsibleModule
+
+DOCUMENTATION = '''
+---
+module: dedicated_server_intervention
+short_description: Enable or disable ovh intervention on a dedicated server
+description:
+    - Enable or disable ovh intervention on a dedicated server
+author: Synthesio SRE Team
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The service_name
+    state:
+        required: true
+        description: Indicate the desired state of intervention
+        choices:
+          - enabled
+          - disabled
+
+'''
+
+EXAMPLES = r'''
+- name: "Enable proactive intervention on dedicated server {{ service_name }}"
+  synthesio.ovh.dedicated_server_intervention:
+    service_name: "{{ service_name }}"
+    state: enabled
+  delegate_to: localhost
+'''
+
+RETURN = ''' # '''
+
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import OVH, ovh_argument_spec
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True),
+        state=dict(choices=['enabled', 'disabled'], default='disabled')
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+    client = OVH(module)
+
+    service_name = module.params['service_name']
+    state = module.params['state']
+
+    if state == 'enabled':
+        noIntervention_bool = False
+    elif state == 'disabled':
+        noIntervention_bool = True
+
+    if module.check_mode:
+        module.exit_json(msg="NoIntervention is now {} for {} - (dry run mode)".format(state, service_name), changed=True)
+
+    server_state = client.wrap_call("GET", f"/dedicated/server/{service_name}")
+
+    if server_state['noIntervention'] == noIntervention_bool:
+        module.exit_json(msg="noIntervention is already {} on {}".format(state, service_name), changed=False)
+
+    client.wrap_call("PUT", f"/dedicated/server/{service_name}", noIntervention=noIntervention_bool)
+
+    module.exit_json(msg="noIntervention is now {} on {}".format(state, service_name), changed=True)
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/dedicated_server_intervention.py
+++ b/plugins/modules/dedicated_server_intervention.py
@@ -20,7 +20,7 @@ options:
         required: true
         description: The service name
     state:
-        required: true
+        required: false
         description: Indicate the desired state of intervention
         choices:
           - enabled

--- a/plugins/modules/dedicated_server_intervention.py
+++ b/plugins/modules/dedicated_server_intervention.py
@@ -12,7 +12,7 @@ module: dedicated_server_intervention
 short_description: Enable or disable ovh intervention on a dedicated server
 description:
     - Enable or disable ovh intervention on a dedicated server
-author: Synthesio SRE Team
+author: tnosaj
 requirements:
     - ovh >= 0.5.0
 options:


### PR DESCRIPTION
Adds ability to enable or disable the manual intervention done by the OVH team: [reference](https://eu.api.ovh.com/console/?section=%2Fdedicated%2Fserver&branch=v1#put-/dedicated/server/-serviceName-)

Somewhat counter intuitively the variable is already a negative (`noIntervetion` in the server object)  - thus the option was abstracted a bit to be more readable:

```
- name: "Enable proactive intervention on dedicated server {{ service_name }}"
  synthesio.ovh.dedicated_server_intervention:
    service_name: "{{ service_name }}"
    state: enabled
  delegate_to: localhost
```
