### PR TITLE
Support additional dedicated server info calls

### DIFF
--- a/plugins/modules/dedicated_server_hardware_info.py
+++ b/plugins/modules/dedicated_server_hardware_info.py
@@ -1,0 +1,206 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+DOCUMENTATION = """
+---
+module: dedicated_server_hardware_info
+short_description: Retrieve hardware specifications for an OVH dedicated server
+description:
+    - This module retrieves detailed hardware specifications for an OVH dedicated server
+author: David Harkis
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The service_name
+"""
+EXAMPLES = r"""
+- name: Retrieve hardware specifications for an OVH dedicated server
+  synthesio.ovh.dedicated_server_hardware_info:
+    service_name: "{{ service_name }}"
+  delegate_to: localhost
+  register: hardware_info
+"""
+RETURN = r"""
+bootMode:
+    description: Server boot mode.
+    returned: always
+    type: str
+    sample: uefi
+coresPerProcessor:
+    description: Number of cores per processor.
+    returned: always
+    type: int
+    sample: 6
+defaultHardwareRaidSize:
+    description: Default hardware raid size for this server.
+    returned: when configured
+    type: dict
+    contains:
+        unit:
+            description: Size unit.
+            type: str
+            sample: GB
+        value:
+            description: Size value.
+            type: int
+            sample: 1000
+defaultHardwareRaidType:
+    description: Default hardware raid type configured on this server.
+    returned: when configured
+    type: str
+    choices: [raid0, raid1, raid10, raid1E, raid5, raid50, raid6, raid60]
+description:
+    description: Commercial name of this server.
+    returned: when available
+    type: str
+    sample: ADVANCE-1 | AMD EPYC 4244P - AMD EPYC 4244P
+diskGroups:
+    description: Details about the groups of disks in the server.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        defaultHardwareRaidSize:
+            description: Default hardware raid size for this disk group.
+            type: dict
+            returned: when configured
+        defaultHardwareRaidType:
+            description: Default hardware raid type for this disk group.
+            type: str
+            returned: when configured
+            choices: [raid0, raid1, raid10, raid1E, raid5, raid50, raid6, raid60]
+        description:
+            description: Human readable description of this disk group.
+            type: str
+            sample: 2 X Disk NVME 960 GB, JBOD
+        diskGroupId:
+            description: Identifier of this disk group.
+            type: int
+            sample: 1
+        diskSize:
+            description: Disk capacity.
+            type: dict
+            contains:
+                unit:
+                    description: Size unit.
+                    type: str
+                    sample: GB
+                value:
+                    description: Size value.
+                    type: int
+                    sample: 960
+        diskType:
+            description: Type of the disk.
+            type: str
+            sample: NVME
+        numberOfDisks:
+            description: Number of disks in this group.
+            type: int
+            sample: 2
+        raidController:
+            description: Raid controller managing this group of disks.
+            type: str
+expansionCards:
+    description: Details about the server's expansion cards.
+    returned: when present
+    type: list
+    elements: dict
+    contains:
+        description:
+            description: Expansion card description.
+            type: str
+        type:
+            description: Expansion card type.
+            type: str
+            choices: [fpga, gpu]
+formFactor:
+    description: Server form factor.
+    returned: always
+    type: str
+    choices: [0.25u, 0.5u, 1u, 2u, 3u, 4u]
+    sample: 0.5u
+memorySize:
+    description: RAM capacity.
+    returned: always
+    type: dict
+    contains:
+        unit:
+            description: Size unit.
+            type: str
+            sample: MB
+        value:
+            description: Size value.
+            type: int
+            sample: 32768
+motherboard:
+    description: Server motherboard.
+    returned: always
+    type: str
+    sample: S3661
+numberOfProcessors:
+    description: Number of processors in this dedicated server.
+    returned: always
+    type: int
+    sample: 1
+processorArchitecture:
+    description: Processor architecture bit.
+    returned: always
+    type: str
+    choices: [arm64, armhf32, ppc64, x86, x86-ht, x86_64]
+    sample: x86_64
+processorName:
+    description: Processor name.
+    returned: always
+    type: str
+    sample: Epyc4244P
+threadsPerProcessor:
+    description: Number of threads per processor.
+    returned: always
+    type: int
+    sample: 12
+usbKeys:
+    description: Capacity of the USB keys installed on your server.
+    returned: when present
+    type: list
+    elements: dict
+    contains:
+        unit:
+            description: Size unit.
+            type: str
+            sample: GB
+        value:
+            description: Size value.
+            type: int"""
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    OVH,
+    ovh_argument_spec,
+)
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(service_name=dict(required=True)))
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    if module.check_mode:
+        module.exit_json(changed=False)
+
+    client = OVH(module)
+    service_name = module.params["service_name"]
+    result = client.wrap_call(
+        "GET", f"/dedicated/server/{service_name}/specifications/hardware"
+    )
+    module.exit_json(changed=False, **result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/dedicated_server_info.py
+++ b/plugins/modules/dedicated_server_info.py
@@ -10,9 +10,9 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: dedicated_server_info
-short_description: Retrieve all info for a OVH dedicated server
+short_description: Retrieve basic info for an OVH dedicated server
 description:
-    - This module retrieves all info for a OVH dedicated server
+    - This module retrieves basic info for an OVH dedicated server
 author: Maxime Dupré
 requirements:
     - ovh >= 0.5.0
@@ -23,7 +23,7 @@ options:
 '''
 
 EXAMPLES = r'''
-- name: Retrieve all info for an OVH dedicated server
+- name: Retrieve basic info for an OVH dedicated server
   synthesio.ovh.dedicated_server_info:
     service_name: "{{ service_name }}"
   delegate_to: localhost

--- a/plugins/modules/dedicated_server_ip_info.py
+++ b/plugins/modules/dedicated_server_ip_info.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+DOCUMENTATION = """
+---
+module: dedicated_server_ip_info
+short_description: Retrieve IP specifications for an OVH dedicated server
+description:
+    - This module retrieves detailed IP specifications for an OVH dedicated server
+author: David Harkis
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The service_name
+"""
+EXAMPLES = r"""
+- name: Retrieve IP specifications for an OVH dedicated server
+  synthesio.ovh.dedicated_server_ip_info:
+    service_name: "{{ service_name }}"
+  delegate_to: localhost
+  register: ip_info
+"""
+RETURN = r"""
+ipv4:
+    description: Orderable IP v4 details.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        blockSizes:
+            description: Orderable IP blocks sizes.
+            type: list
+            elements: int
+            sample: [1, 4, 8, 16, 32, 64, 128]
+        included:
+            description: Are those IP included with your offer.
+            type: bool
+            sample: true
+        ipNumber:
+            description: Total number of IP that can be routed to this server.
+            type: int
+            sample: 256
+        number:
+            description: Total number of prefixes that can be routed to this server.
+            type: int
+            sample: 254
+        optionRequired:
+            description: Which option is required to order this type of IP.
+            type: str
+            choices: [professionalUse]
+        type:
+            description: This IP type.
+            type: str
+            choices: [failover, static, unshielded]
+            sample: failover
+ipv6:
+    description: Orderable IP v6 details.
+    returned: always
+    type: list
+    elements: dict
+    contains:
+        blockSizes:
+            description: Orderable IP blocks sizes.
+            type: list
+            elements: int
+            choices: [1, 4, 8, 16, 32, 64, 128, 256]
+        included:
+            description: Are those IP included with your offer.
+            type: bool
+        ipNumber:
+            description: Total number of IP that can be routed to this server.
+            type: int
+        number:
+            description: Total number of prefixes that can be routed to this server.
+            type: int
+        optionRequired:
+            description: Which option is required to order this type of IP.
+            type: str
+            choices: [professionalUse]
+        type:
+            description: This IP type.
+            type: str
+            choices: [failover, static, unshielded]"""
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    OVH,
+    ovh_argument_spec,
+)
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(service_name=dict(required=True)))
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    if module.check_mode:
+        module.exit_json(changed=False)
+
+    client = OVH(module)
+    service_name = module.params["service_name"]
+    result = client.wrap_call(
+        "GET", f"/dedicated/server/{service_name}/specifications/ip"
+    )
+    module.exit_json(changed=False, **result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/dedicated_server_network_info.py
+++ b/plugins/modules/dedicated_server_network_info.py
@@ -1,0 +1,264 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function
+from ansible.module_utils.basic import AnsibleModule
+
+__metaclass__ = type
+DOCUMENTATION = """
+---
+module: dedicated_server_network_info
+short_description: Retrieve network specifications for an OVH dedicated server
+description:
+    - This module retrieves detailed network specifications for an OVH dedicated server
+author: David Harkis
+requirements:
+    - ovh >= 0.5.0
+options:
+    service_name:
+        required: true
+        description: The service_name
+"""
+EXAMPLES = r"""
+- name: Retrieve network specifications for an OVH dedicated server
+  synthesio.ovh.dedicated_server_network_info:
+    service_name: "{{ service_name }}"
+  delegate_to: localhost
+  register: network_info
+"""
+RETURN = r"""
+bandwidth:
+    description: Bandwidth details.
+    returned: always
+    type: dict
+    contains:
+        InternetToOvh:
+            description: Bandwidth limitation Internet to OVH.
+            type: dict
+            contains:
+                unit:
+                    description: Bandwidth unit.
+                    type: str
+                    sample: Mbps
+                value:
+                    description: Bandwidth value.
+                    type: int
+                    sample: 1000
+        OvhToInternet:
+            description: Bandwidth limitation OVH to Internet.
+            type: dict
+            contains:
+                unit:
+                    description: Bandwidth unit.
+                    type: str
+                    sample: Mbps
+                value:
+                    description: Bandwidth value.
+                    type: int
+                    sample: 1000
+        OvhToOvh:
+            description: Bandwidth limitation OVH to OVH.
+            type: dict
+            contains:
+                unit:
+                    description: Bandwidth unit.
+                    type: str
+                    sample: Mbps
+                value:
+                    description: Bandwidth value.
+                    type: int
+                    sample: 1000
+        type:
+            description: Bandwidth offer type.
+            type: str
+            choices: [improved, included, platinum, premium, standard, ultimate]
+            sample: included
+connection:
+    description: Network connection flow rate.
+    returned: always
+    type: dict
+    contains:
+        unit:
+            description: Flow rate unit.
+            type: str
+            sample: Mbps
+        value:
+            description: Flow rate value.
+            type: int
+            sample: 25000
+ola:
+    description: OLA details.
+    returned: always
+    type: dict
+    contains:
+        available:
+            description: Is the OLA feature available.
+            type: bool
+            sample: true
+        availableModes:
+            description: What modes are supported.
+            type: list
+            elements: dict
+            contains:
+                default:
+                    description: Is this the default mode.
+                    type: bool
+                    sample: true
+                interfaces:
+                    description: Network interfaces configuration.
+                    type: list
+                    elements: dict
+                    contains:
+                        aggregation:
+                            description: Is aggregation enabled.
+                            type: bool
+                            sample: true
+                        count:
+                            description: Number of interfaces.
+                            type: int
+                            sample: 2
+                        type:
+                            description: Interface type.
+                            type: str
+                            sample: public
+                name:
+                    description: Mode name.
+                    type: str
+                    sample: public(2)+private(2)
+        supportedModes:
+            description: Supported modes.
+            type: list
+            elements: str
+            sample: ["vrack_aggregation"]
+routing:
+    description: Routing details.
+    returned: always
+    type: dict
+    contains:
+        ipv4:
+            description: IPv4 routing details.
+            type: dict
+            contains:
+                gateway:
+                    description: IPv4 gateway.
+                    type: str
+                    sample: 100.64.0.1
+                ip:
+                    description: IPv4 address.
+                    type: str
+                    sample: 57.129.64.192
+                network:
+                    description: IPv4 network.
+                    type: str
+                    sample: 57.129.64.0/24
+        ipv6:
+            description: IPv6 routing details.
+            type: dict
+            contains:
+                gateway:
+                    description: IPv6 gateway.
+                    type: str
+                    sample: fe80:0000:0000:0000:0000:0000:0000:0001
+                ip:
+                    description: IPv6 address.
+                    type: str
+                    sample: 2001:41d0:070f:c000:0000:0000:0000:0000/56
+                network:
+                    description: IPv6 network.
+                    type: str
+                    sample: 2001:41d0:70f::0000/48
+switching:
+    description: Switching details.
+    returned: always
+    type: dict
+    contains:
+        name:
+            description: Switch name.
+            type: str
+            sample: fra1-lim3-unettor99a-n93
+traffic:
+    description: Traffic details.
+    returned: always
+    type: dict
+    contains:
+        inputQuotaSize:
+            description: Monthly input traffic quota allowed.
+            type: dict
+        inputQuotaUsed:
+            description: Monthly input traffic consumed this month.
+            type: dict
+        isThrottled:
+            description: Is bandwidth throttled for being over quota.
+            type: bool
+            sample: false
+        outputQuotaSize:
+            description: Monthly output traffic quota allowed.
+            type: dict
+        outputQuotaUsed:
+            description: Monthly output traffic consumed this month.
+            type: dict
+        resetQuotaDate:
+            description: Next reset quota date for traffic counter.
+            type: str
+vmac:
+    description: VMAC information for this dedicated server.
+    returned: always
+    type: dict
+    contains:
+        quota:
+            description: Maximum number of VirtualMacs allowed on this server.
+            type: int
+            sample: 32
+        supported:
+            description: Server is compatible with vmac or not.
+            type: bool
+            sample: true
+vrack:
+    description: vRack details.
+    returned: when configured
+    type: dict
+    contains:
+        bandwidth:
+            description: vRack bandwidth limitation.
+            type: dict
+            contains:
+                unit:
+                    description: Bandwidth unit.
+                    type: str
+                    sample: Mbps
+                value:
+                    description: Bandwidth value.
+                    type: int
+                    sample: 25000
+        type:
+            description: Bandwidth offer type.
+            type: str
+            choices: [included, standard]
+            sample: standard"""
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    OVH,
+    ovh_argument_spec,
+)
+
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(service_name=dict(required=True)))
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+    if module.check_mode:
+        module.exit_json(changed=False)
+
+    client = OVH(module)
+    service_name = module.params["service_name"]
+    result = client.wrap_call(
+        "GET", f"/dedicated/server/{service_name}/specifications/network"
+    )
+    module.exit_json(changed=False, **result)
+
+
+def main():
+    run_module()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
The OVH API exposes additional dedicated server 'info' endpoints, providing values that are not in the base info endpoint. This PR adds three new info modules to retrieve this data, each based on the original info module:

`dedicated/server/{service_name}/specifications/hardware` -> `dedicated_server_hardware_info`
- Detailed processor specifications (cores, threads, architecture)
- Complete disk configurations including RAID options
- Detailed memory specifications
- Hardware model information

`dedicated/server/{service_name}/specifications/ip` -> `dedicated_server_ip_info`
- IP address block details and quotas
- Full IPv4 and IPv6 configuration

`dedicated/server/{service_name}/specifications/network` -> `dedicated_server_network_info`
- Detailed bandwidth and routing configuration
- Network interface settings and capabilities
- Traffic management information