### PR TITLE
Using a module decorator to reduce code duplication

### DIFF
--- a/plugins/modules/ip_reverse.py
+++ b/plugins/modules/ip_reverse.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: ip_reverse
 short_description: Modify reverse on IP
@@ -28,73 +28,78 @@ options:
         description: The ipBlock (only for vrack IPs)
         default: None
 
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Modify reverse on IP
   synthesio.ovh.ip_reverse:
     ip: 192.0.2.1
     reverse: host.domain.example.
   delegate_to: localhost
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import OVH, OVHResourceNotFound, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    OVH,
+    ResourceNotFound,
+    ovh_argument_spec,
+)
 import urllib.parse
 
 
 def run_module():
     module_args = ovh_argument_spec()
-    module_args.update(dict(
-        ip=dict(required=True),
-        reverse=dict(required=True),
-        ip_block=dict(required=False, default=None)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
+    module_args.update(
+        dict(
+            ip=dict(required=True),
+            reverse=dict(required=True),
+            ip_block=dict(required=False, default=None),
+        )
     )
+
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
     client = OVH(module)
 
-    ip = module.params['ip']
-    reverse = module.params['reverse']
-    ip_block = module.params['ip_block']
+    ip = module.params["ip"]
+    reverse = module.params["reverse"]
+    ip_block = module.params["ip_block"]
 
     # ip_block is only needed for vrack IPs. Default it to "ip" when not used
     if ip_block is None:
         ip_block = ip
     else:
         # url encode the ip mask (/26 -> %2F)
-        ip_block = urllib.parse.quote(ip_block, safe='')
+        ip_block = urllib.parse.quote(ip_block, safe="")
 
     if module.check_mode:
-        module.exit_json(msg="Reverse {} to {} succesfully set ! - (dry run mode)".format(ip, reverse), changed=True)
+        module.exit_json(
+            msg="Reverse {} to {} succesfully set ! - (dry run mode)".format(
+                ip, reverse
+            ),
+            changed=True,
+        )
 
     result = {}
     try:
         result = client.wrap_call("GET", f"/ip/{ip_block}/reverse/{ip}")
-    except OVHResourceNotFound:
-        result['reverse'] = ''
+    except ResourceNotFound:
+        result["reverse"] = ""
 
-    if result['reverse'] == reverse:
-        module.exit_json(msg="Reverse {} to {} already set !".format(ip, reverse), changed=False)
+    if result["reverse"] == reverse:
+        module.exit_json(
+            msg="Reverse {} to {} already set !".format(ip, reverse), changed=False
+        )
 
-    client.wrap_call(
-        "POST",
-        f"/ip/{ip_block}/reverse",
-        ipReverse=ip,
-        reverse=reverse
-    )
+    client.wrap_call("POST", f"/ip/{ip_block}/reverse", ipReverse=ip, reverse=reverse)
     module.exit_json(
-        msg="Reverse {} to {} succesfully set !".format(ip, reverse),
-        changed=True)
+        msg="Reverse {} to {} succesfully set !".format(ip, reverse), changed=True
+    )
 
 
 def main():
     run_module()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/vps_info.py
+++ b/plugins/modules/vps_info.py
@@ -1,13 +1,13 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
+from __future__ import absolute_import, division, print_function
 
 from ansible.module_utils.basic import AnsibleModule
 
 __metaclass__ = type
 
-DOCUMENTATION = '''
+DOCUMENTATION = """
 ---
 module: vps_info
 short_description: Retrieve all info for a OVH vps
@@ -20,42 +20,30 @@ options:
     service_name:
         required: true
         description: The service name
-'''
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 - name: Retrieve all info for an OVH vps
   synthesio.ovh.vps_info:
     service_name: "{{ service_name }}"
   delegate_to: localhost
   register: vps_info
-'''
+"""
 
-RETURN = ''' # '''
+RETURN = """ # """
 
-from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import OVH, ovh_argument_spec
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import (
+    OVH,
+    collection_module,
+)
 
 
-def run_module():
-    module_args = ovh_argument_spec()
-    module_args.update(dict(
-        service_name=dict(required=True)
-    ))
-
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
-    )
-    client = OVH(module)
-
-    service_name = module.params['service_name']
+@collection_module(dict(service_name=dict(required=True)))
+def main(module: AnsibleModule, client: OVH, service_name: str):
     result = client.wrap_call("GET", f"/vps/{service_name}")
 
     module.exit_json(changed=False, **result)
 
 
-def main():
-    run_module()
-
-
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
Hi!

Thanks for this package, long time OVH user here, but recently started using Ansible more seriously. I am currently working on adding quite a few VPS endpoints, but I noticed a rather funky pattern where the AnsibleModule and OVH client are created in every single function.

Additionally, creating a 'run_module' function, to creating a 'main' which only calls the 'run_module'.

This draft PR show a simple example of how I changed the code for my fork, and I would not mind creating a proper PR if you agree with this change on a collection-wide scale. I can imagine this might be a bit invasive so hence the Draft PR.

I tested this implementation (vps_info.py) without any issues (identical behavior).

p.s. The changes to the strings / layout is due to Ruff. I highly recommend switching to Ruff instead of using flake8. Please ignore the 'ip_reverse.py' file.