### PR TITLE
End of life for personal installation templates

### DIFF
--- a/plugins/modules/dedicated_server_reinstall.py
+++ b/plugins/modules/dedicated_server_reinstall.py
@@ -38,7 +38,7 @@ options:
 EXAMPLES = r'''
 - name: Reinstall OVH server
   dedicated_server_reinstall:
-    service_name: "ns3255155.ip-217-182-89.eu"
+    service_name: "xxx.ip-xxx-xx-xx.eu"
     operating_system: "debian12_64"
     hostname: "ceph-2"
     ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"

--- a/plugins/modules/dedicated_server_reinstall.py
+++ b/plugins/modules/dedicated_server_reinstall.py
@@ -1,0 +1,120 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: dedicated_server_reinstall
+short_description: Reinstall a dedicated server using OVH API
+description:
+    - Reinstall an OVH dedicated server using a specific OS, hostname, SSH key, and custom storage layout.
+author:
+    - "Inspired by Synthesio SRE team"
+options:
+    service_name:
+        required: true
+        type: str
+        description: OVH service name (e.g. nsXXXX.ip-XXX)
+    operating_system:
+        required: true
+        type: str
+        description: OS template to use (e.g. debian12_64)
+    hostname:
+        required: true
+        type: str
+        description: Hostname to assign
+    ssh_key:
+        required: true
+        type: str
+        description: SSH public key string
+    storage:
+        required: true
+        type: list
+        description: Disk layout config (diskGroupId, RAID, etc.)
+'''
+
+EXAMPLES = r'''
+- name: Reinstall OVH server
+  dedicated_server_reinstall:
+    service_name: "ns3255155.ip-217-182-89.eu"
+    operating_system: "debian12_64"
+    hostname: "ceph-2"
+    ssh_key: "{{ lookup('file', '~/.ssh/id_rsa.pub') }}"
+    storage:
+      - diskGroupId: 1
+        partitioning:
+          disks: 2
+          layout:
+            - fileSystem: ext4
+              mountPoint: /boot
+              raidLevel: 1
+              size: 2048
+            - fileSystem: ext4
+              mountPoint: /
+              raidLevel: 1
+              size: 0
+'''
+
+RETURN = '''
+task_id:
+  description: Task ID of the reinstall operation
+  returned: always
+  type: int
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import OVH, ovh_argument_spec
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(type="str", required=True),
+        operating_system=dict(type="str", required=True),
+        hostname=dict(type="str", required=True),
+        ssh_key=dict(type="str", required=True),
+        storage=dict(type="list", required=True)
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    client = OVH(module)
+
+    service_name = module.params['service_name']
+    os = module.params['operating_system']
+    hostname = module.params['hostname']
+    ssh_key = module.params['ssh_key']
+    storage = module.params['storage']
+
+    if module.check_mode:
+        module.exit_json(changed=True, msg="[CHECK_MODE] Would reinstall server with provided config")
+
+    try:
+        result = client.wrap_call(
+            "POST",
+            f"/dedicated/server/{service_name}/reinstall",
+            operatingSystem=os,
+            customizations={
+                "hostname": hostname,
+                "sshKey": ssh_key
+            },
+            storage=storage
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Failed to trigger reinstall: {str(e)}")
+
+    module.exit_json(
+        changed=True,
+        msg=f"Reinstall triggered for {service_name}",
+        task_id=result.get("taskId")
+    )
+
+def main():
+    run_module()
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/dedicated_server_task_status.py
+++ b/plugins/modules/dedicated_server_task_status.py
@@ -24,8 +24,8 @@ options:
 EXAMPLES = '''
 - name: Check OVH task status
   dedicated_server_task_status:
-    service_name: "ns3254307.ip-217-182-91.eu"
-    task_id: 469647709
+    service_name: "xxxx.ip-xx-xx-xx.eu"
+    task_id: xxxxxx
   register: task_status
 
 - debug:

--- a/plugins/modules/dedicated_server_task_status.py
+++ b/plugins/modules/dedicated_server_task_status.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+DOCUMENTATION = '''
+---
+module: dedicated_server_task_status
+short_description: Check the status of an OVH server task
+description:
+    - Query OVH API to check the status of a dedicated server task (reinstall, etc.)
+author:
+    - "Adapted by OpenAI from Synthesio style"
+options:
+    service_name:
+        required: true
+        type: str
+        description: The OVH service name of the server (e.g. nsXXXX.ip-...)
+    task_id:
+        required: true
+        type: int
+        description: The task ID returned by a previous action (e.g. reinstall)
+'''
+
+EXAMPLES = '''
+- name: Check OVH task status
+  dedicated_server_task_status:
+    service_name: "ns3254307.ip-217-182-91.eu"
+    task_id: 469647709
+  register: task_status
+
+- debug:
+    msg: "Task status is {{ task_status.status }}"
+'''
+
+RETURN = '''
+status:
+  description: Status of the task (e.g., "done", "running", "error")
+  type: str
+  returned: always
+result:
+  description: Full API response from OVH
+  type: dict
+  returned: always
+'''
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.synthesio.ovh.plugins.module_utils.ovh import OVH, ovh_argument_spec
+
+def run_module():
+    module_args = ovh_argument_spec()
+    module_args.update(dict(
+        service_name=dict(required=True, type='str'),
+        task_id=dict(required=True, type='int'),
+    ))
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=True
+    )
+
+    client = OVH(module)
+
+    service_name = module.params['service_name']
+    task_id = module.params['task_id']
+
+    try:
+        result = client.wrap_call(
+            "GET",
+            f"/dedicated/server/{service_name}/task/{task_id}"
+        )
+    except Exception as e:
+        module.fail_json(msg=f"Failed to fetch task status: {str(e)}")
+
+    module.exit_json(
+        changed=False,
+        status=result.get("status"),
+        result=result
+    )
+
+
+def main():
+    run_module()
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/dedicated_server_task_status.py
+++ b/plugins/modules/dedicated_server_task_status.py
@@ -10,8 +10,6 @@ module: dedicated_server_task_status
 short_description: Check the status of an OVH server task
 description:
     - Query OVH API to check the status of a dedicated server task (reinstall, etc.)
-author:
-    - "Adapted by OpenAI from Synthesio style"
 options:
     service_name:
         required: true


### PR DESCRIPTION
Note: The use of personal installation templates is no longer supported by OVH Cloud, as per their [official announcement](https://help.ovhcloud.com/csm/en-dedicated-servers-end-of-life-for-personal-installation-templates?id=kb_article_view&sysparm_article=KB0067557).

To adapt to this change, I have implemented:

A module to automate server reinstallation with partitioning

A module to track the time it takes for the server to become fully ready after reinstall